### PR TITLE
Create fb_team_abvs.csv

### DIFF
--- a/fb_team_abvs.csv
+++ b/fb_team_abvs.csv
@@ -1,0 +1,772 @@
+Team Name,School Name,Team Mascot,Conference,Division,Club Code,Club Code 2,NFS Team Code,NCAA ID
+Abilene Christian Wildcats,Abilene Christian University,Wildcats,Southland Conference,1AA,ACU,ABC,TXAC,2
+Adams State Grizzlies,Adams State College,Grizzlies,Rocky Mountain Athletic Conference,2,ADA,ASC,COAD,929
+Adrian Bulldogs,Adrian College,Bulldogs,Michigan Intercollegiate Athletic Association,3,ADR,ADC,MIAD,4
+Air Force Academy Falcons,United States Air Force Academy,Falcons,Mountain West Conference,1A,AIR,AF,COAF,721
+Akron Zips,University of Akron,Zips,Mid-American Conference,1A,AKR,ZIP,OHAK,5
+Alabama A&M Bulldogs,Alabama A&M University,Bulldogs,Southwestern Athletic Conference,1AA,ALA,AAM,ALAM,6
+Alabama Crimson Tide,University of Alabama,Crimson Tide,Southeastern Conference,1A,AL,ALA,ALUN,8
+Alabama State Hornets,Alabama State University,Hornets,Southwestern Athletic Conference,1AA,ALH,ALA,ALST,7
+Alabama-Birmingham Blazers,University of Alabama-Birmingham,Blazers,Conference USA,1A,UAB,ALA,ALBI,9
+Albany Great Danes,University at Albany,Great Danes,Colonial Athletic Association,1AA,ALB,ABY,NYAB,14
+Albany State Rams,Albany State University,Rams,Southern Intercollegiate Athletic Conference,2,ASR,ABY,GAAL,13
+Albion Britons,Albion College,Britons,Michigan Intercollegiate Athletic Association,3,ABB,ABC,MIAB,15
+Albright Lions,Albright College,Lions,Middle Atlantic Conference,3,ABL,ABC,PAAB,16
+Alcorn State Braves,Alcorn State University,Braves,Southwestern Athletic Conference,1AA,ALC,ASU,MSAL,17
+Alderson Broaddus Battlers,Alderson Broaddus University,Battlers,Independent,2,AB,ALD,WVAB,934
+Alfred Saxons,Alfred University,Saxons,Empire 8 Conference,3,ALF,ALU,NYAF,18
+Alfred State Pioneers,Alfred State SUNY College of Technology,Pioneers,Independent,3,ASP,AS,NYAL,30170
+Allegheny Gators,Allegheny College,Gators,North Coast Athletic Conference,3,ALE,ALG,PAAG,19
+Alma Scots,Alma College,Scots,Michigan Intercollegiate Athletic Association,3,ALM,ALA,MIAM,21
+Alvernia Golden Wolves,Alvernia University,Golden Wolves,Presidents Athletic Conference,3,ALV,ALU,PAAV,938
+American International Yellow Jackets,American International College,Yellow Jackets,Northeast-10 Conference,2,AI,AIU,MAAI,22
+Amherst Jeffs,Amherst College,Jeffs,New England Small College Athletic Conference,3,AMH,AC,MAAM,24
+Anderson Ravens,Anderson University,Ravens,Heartland Collegiate Athletic Conference,3,AND,AU,INAN,939
+Angelo State Rams,Angelo State University,Rams,Lone Star Conference,2,ANG,ASU,TXAN,25
+Anna Maria AmCats,Anna Maria College,AmCats,Eastern Collegiate Football Conference,3,AM,AMC,MAAN,26
+Appalachian State Mountaineers,Appalachian State University,Mountaineers,Sun Belt Conference,1A,APP,ASU,NCAP,27
+Arizona Christian Firestorm,Arizona Christian University,Firestorm,Independent,NAIA,AC,ACU,AZCH,504994
+Arizona State Sun Devils,Arizona State University,Sun Devils,Pacific Twelve Conference,1A,ASU,ARZ,AZST,28
+Arizona Wildcats,University of Arizona,Wildcats,Pacific Twelve Conference,1A,AZ,ARZ,AZUN,29
+Arkansas Razorbacks,University of Arkansas,Razorbacks,Southeastern Conference,1A,AR,ARK,ARUN,31
+Arkansas State Red Wolves,Arkansas State University,Red Wolves,Sun Belt Conference,1A,ARW,ARK,ARST,30
+Arkansas Tech Wonder Boys,Arkansas Tech University,Wonder Boys,Great American Conference,2,ATU,ARK,ARTC,947
+Arkansas-Monticello Boll Weevils,University of Arkansas-Monticello,Boll Weevils,Great American Conference,2,ARK,ARM,ARMO,8411
+Arkansas-Pine Bluff Golden Lions,University of Arkansas-Pine Bluff,Golden Lions,Southwestern Athletic Conference,1AA,UAP,ARK,ARPB,2678
+Army Black Knights,United States Military Academy,Black Knights,Independent,1A,ARM,ARY,NYWP,725
+Ashland Eagles,Ashland University,Eagles,Great Lakes Intercollegiate Athletic Conference,2,ASH,AU,OHAS,35
+Assumption Greyhounds,Assumption College,Greyhounds,Northeast-10 Conference,2,ASS,AC,MAAS,36
+Auburn Tigers,Auburn University,Tigers,Southeastern Conference,1A,AUB,AU,ALAU,37
+Augsburg Auggies,Augsburg College,Auggies,Minnesota Intercollegiate Athletic Conference,3,AUA,AC,MNAV,38
+Augustana College Vikings,Augustana College (S.D.),Vikings,Northern Sun Intercollegiate Conference,2,AUG,AC,SDAU,41
+Augustana Vikings,Augustana College (Ill.),Vikings,College Conference of Illinois and Wisconsin,3,ACV,AC,ILAU,40
+Aurora Spartans,Aurora University,Spartans,Northern Athletics Conference,3,AUR,ARA,ILAR,42
+Austin Kangaroos,Austin College,Kangaroos,Southern Collegiate Athletic Conference,3,AUS,AC,TXAU,953
+Austin Peay Governors,Austin Peay State University,Governors,Ohio Valley Conference,1AA,APY,AUS,TNAP,43
+Ave Maria Gyrenes,Ave Maria University,Gyrenes,The Sun Conference,NAIA,AVE,AM,FLAV,506346
+Averett Cougars,Averett University,Cougars,USA South Athletic Conference,3,AVE,AVR,VAAV,44
+Azusa Pacific Cougars,Azusa Pacific University,Cougars,Great Northwest Athletic Conference,2,AP,APU,CAAZ,30146
+Bacone Warriors,Bacone College,Warriors,Central States Football League,NAIA,BAC,BC,OKBC,506174
+Baker Wildcats,Baker University,Wildcats,Heart of America Athletic Conference,NAIA,BAK,BU,KSBA,506059
+Baldwin-Wallace Yellow Jackets,Baldwin-Wallace College,Yellow Jackets,Ohio Athletic Conference,3,BW,BAL,OHBW,46
+Ball State Cardinals,Ball State University,Cardinals,Mid-American Conference,1A,BAL,BSU,INBS,47
+Bates Bobcats,Bates College,Bobcats,New England Small College Athletic Conference,3,BAT,BC,MEBA,50
+Baylor Bears,Baylor University,Bears,Big Twelve Conference,1A,BAY,BU,TXBA,51
+Becker Hawks,Becker College,Hawks,Eastern Collegiate Football Conference,3,BEC,BC,MABK,26107
+Belhaven Blazers,Belhaven University,Blazers,Mid-South Conference,NAIA,BEL,BU,MSBH,30197
+Beloit Buccaneers,Beloit College,Buccaneers,Midwest Conference,3,BEL,BC,WIBE,53
+Bemidji State Beavers,Bemidji State University,Beavers,Northern Sun Intercollegiate Conference,2,BSU,BEM,MNBM,54
+Benedict Tigers,Benedict College,Tigers,Southern Intercollegiate Athletic Conference,2,BEN,BC,SCBC,55
+Benedictine Eagles,Benedictine University,Eagles,Northern Athletics Conference,3,BUE,BU,ILBE,296
+Benedictine Ravens,Benedictine College,Ravens,Heart of America Athletic Conference,NAIA,BEN,BC,KSBN,506015
+Bentley Falcons,Bentley College,Falcons,Northeast-10 Conference,2,BNT,BTY,MABE,56
+Berry Vikings,Berry College,Vikings,Southern Athletic Association,3,BER,BC,GABE,973
+Bethany Bison,Bethany College,Bison,Presidents Athletic Conference,3,BET,BTH,WVBE,59
+Bethany Swedes,Bethany College,Swedes,Kansas Collegiate Athletic Conference,NAIA,BET,BTH,KSBY,506014
+Bethel Royals,Bethel University,Royals,Minnesota Intercollegiate Athletic Conference,3,BTR,BTH,MNBT,60
+Bethel Threshers,Bethel College (Kan.),Threshers,Kansas Collegiate Athletic Conference,NAIA,BET,BTH,KSBL,506120
+Bethel Wildcats,Bethel University,Wildcats,Mid-South Conference,NAIA,BET,BU,TNBC,500500
+Bethune-Cookman Wildcats,Bethune-Cookman College,Wildcats,Mid-Eastern Athletic Conference,1AA,BCC,BET,FLBC,61
+Birmingham-Southern Panthers,Birmingham-Southern College,Panthers,Southern Athletic Association,3,BS,BSC,ALBS,28593
+Black Hills Yellow Jackets,Black Hills State University,Yellow Jackets,Rocky Mountain Athletic Conference,2,BH,BHS,SDBH,30134
+Bloomsburg Huskies,Bloomsburg University,Huskies,Pennsylvania State Athletic Conference,2,BLO,BU,PABL,65
+Bluefield Rams,Bluefield College,Rams,Mid-South Conference,NAIA,BLU,BC,VABL,500552
+Bluffton Beavers,Bluffton College,Beavers,Heartland Collegiate Athletic Conference,3,BLF,BLU,OHBL,987
+Boise State Broncos,Boise State University,Broncos,Mountain West Conference,1A,BOI,BSU,IDBO,66
+Boston College Eagles,Boston College,Eagles,Atlantic Coast Conference,1A,BC,BOS,MABC,67
+Bowdoin Polar Bears,Bowdoin College,Polar Bears,New England Small College Athletic Conference,3,BPB,BC,MEBO,69
+Bowie State Bulldogs,Bowie State University,Bulldogs,Central Intercollegiate Athletic Association,2,BOW,BSU,MDBO,70
+Bowling Green Falcons,Bowling Green State University,Falcons,Mid-American Conference,1A,BG,BGS,OHBG,71
+Brevard Tornados,Brevard College,Tornados,South Atlantic Conference,2,BRE,BRV,NCBR,30094
+Briar Cliff Chargers,Briar Cliff University,Chargers,Great Plains Athletic Conference,NAIA,BRI,BC,IABC,500615
+Bridgewater College,Bridgewater College,Eagles,Old Dominion Athletic Conference,3,BRI,BC,VABR,75
+Bridgewater State Bears,Bridgewater State College,Bears,Massachusetts State College Athletic Conference,3,BCB,BSC,MABR,76
+Brigham Young Cougars,Brigham Young University,Cougars,Independent,1A,BYU,BY,UTBY,77
+Brown Bears,Brown University,Bears,Ivy League,1AA,BU,BRO,RIBR,80
+Bryant Bulldogs,Bryant University,Bulldogs,Northeast Conference,1AA,BRY,BU,RIBT,81
+Bucknell Bison,Bucknell University,Bison,Patriot League,1AA,BCK,BUC,PABU,83
+Buena Vista Beavers,Buena Vista University,Beavers,Iowa Intercollegiate Athletic Conference,3,BV,BUE,IABV,84
+Buffalo Bulls,University at Buffalo,Bulls,Mid-American Conference,1A,BUF,UB,NYBU,86
+Buffalo State Bengals,Buffalo State College,Bengals,Empire 8 Conference,3,BSB,BSC,NYBC,85
+Butler Bulldogs,Butler University,Bulldogs,Pioneer Football League,1AA,BUT,BU,INBU,87
+Cal Poly Mustangs,California Poly State University,Mustangs,Big Sky Conference,1AA,CPS,A,CASL,90
+Calgary Dinos,University of Calgary,Dinos,Canada West Universities Athletic Association,Canada,CAL,CL,CNCA,506453
+California Lutheran Kingsmen,California Lutheran University,Kingsmen,Southern California Intercollegiate Athletic Conf.,3,CAL,CLU,CALU,105
+California State Sacramento Hornets,California State University-Sacramento,Hornets,Big Sky Conference,1AA,CAS,CSU,CASA,102
+California University of Pennsylvania Vulcans,California University of Pennsylvania,Vulcans,Pennsylvania State Athletic Conference,2,CPA,CAL,PACS,106
+California-Berkeley Golden Bears,University of California-Berkeley,Golden Bears,Pacific Twelve Conference,1A,UCB,CAL,CAUN,107
+California-Davis Aggies,University of California-Davis,Aggies,Big Sky Conference,1AA,UCD,CAD,CADA,108
+California-Los Angeles Bruins,University of California-Los Angeles,Bruins,Pacific Twelve Conference,1A,CLA,UCL,CALA,110
+Campbell Camels,Campbell University,Camels,Pioneer Football League,1AA,CAM,CU,NCCM,115
+Campbellsville Tigers,Campbellsville University,Tigers,Mid-South Conference,NAIA,CAM,CU,KYCA,500785
+Capital Crusaders,Capital University,Crusaders,Ohio Athletic Conference,3,CAP,CU,OHCU,117
+Carleton Knights,Carleton College,Knights,Minnesota Intercollegiate Athletic Conference,3,CAR,CC,MNCA,118
+Carnegie Mellon Tartans,Carnegie Mellon University,Tartans,Presidents Athletic Conference,3,CM,CAR,PACA,119
+Carroll Fighting Saints,Carroll College,Fighting Saints,Frontier Conference,NAIA,CAR,CC,MTCA,506056
+Carroll Pioneers,Carroll University,Pioneers,Midwest Conference,3,CCP,CU,WICL,120
+Carson-Newman Eagles,Carson-Newman College,Eagles,South Atlantic Conference,2,CNC,CAR,TNCN,1000
+Carthage Red Men,Carthage College,Red Men,College Conference of Illinois and Wisconsin,3,CRM,CTH,WICG,121
+Case Western Reserve Spartans,Case Western Reserve University,Spartans,Presidents Athletic Conference,3,CWR,CAS,OHCW,122
+Castleton Spartans,Castleton State College,Spartans,Eastern Collegiate Football Conference,3,CUS,CSC,VTCA,123
+Catawba Indians,Catawba College,Indians,South Atlantic Conference,2,CAT,CAW,NCCA,1001
+Catholic Cardinals,The Catholic University of America,Cardinals,Old Dominion Athletic Conference,3,CUA,CAT,DCCA,124
+Central Arkansas Bears,University of Central Arkansas,Bears,Southland Conference,1AA,UCA,CAR,ARCE,1004
+Central Connecticut Blue Devils,Central Connecticut State University,Blue Devils,Northeast Conference,1AA,CCS,CEN,CTCE,127
+Central Dutch,Central College,Dutch,Iowa Intercollegiate Athletic Conference,3,CCD,CC,IACE,126
+Central Florida Knights,University of Central Florida,Knights,American Athletic Conference,1A,UCF,CF,FLCE,128
+Central Methodist Eagles,Central Methodist University,Eagles,Heart of America Athletic Conference,NAIA,CM,CMU,MOCM,506026
+Central Michigan Chippewas,Central Michigan University,Chippewas,Mid-American Conference,1A,CMU,CEN,MICE,129
+Central Missouri Mules,University of Central Missouri,Mules,Mid-America Intercollegiate Athletic Association,2,UCM,CEM,MOCE,130
+Central Oklahoma Bronchos,University of Central Oklahoma,Bronchos,Mid-America Intercollegiate Athletic Association,2,COB,CEN,OKCE,1009
+Central State Marauders,Central State University,Marauders,Southern Intercollegiate Athletic Conference,2,CEN,CSU,OHCE,30049
+Central Washington Wildcats,Central Washington University,Wildcats,Great Northwest Athletic Conference,2,CWU,CEN,WACE,1010
+Centre Colonels,Centre College,Colonels,Southern Athletic Association,3,CCC,CC,KYCN,132
+Chadron State Eagles,Chadron State College,Eagles,Rocky Mountain Athletic Conference,2,CSE,CSC,NECH,1012
+Chapman Panthers,Chapman University,Panthers,Southern California Intercollegiate Athletic Conf.,3,CUP,CU,CACC,134
+Charleston Golden Eagles,University of Charleston,Golden Eagles,Mountain East Conference,2,CH,UC,WVCH,1013
+Charleston Southern Buccaneers,Charleston Southern University,Buccaneers,Big South Conference,1AA,CHA,CSU,SCCH,48
+Charlotte 49ers,University of North Carolina - Charlotte,49ers,Conference USA,1A,NCC,CHA,NCCR,458
+Cheyney Wolves,Cheyney University,Wolves,Pennsylvania State Athletic Conference,2,CHY,CHE,PACH,135
+Chicago Maroons,University of Chicago,Maroons,Independent,3,CHI,UC,ILCH,137
+Chowan Hawks,Chowan College,Hawks,Central Intercollegiate Athletic Association,2,CHW,CHO,NCCH,8875
+Christopher Newport Captains,Christopher Newport University,Captains,New Jersey Athletic Conference,3,CNU,CHR,VACN,139
+Cincinnati Bearcats,University of Cincinnati,Bearcats,American Athletic Conference,1A,CIN,UC,OHCI,140
+Citadel Bulldogs,The Citadel,Bulldogs,Southern Conference,1AA,CIT,TC,SCCI,141
+Claremont-Mudd-Scripps Stags,Claremont-Mudd-Scripps Colleges,Stags,Southern California Intercollegiate Athletic Conf.,3,CMS,CLA,CACM,142
+Clarion Golden Eagles,Clarion University,Golden Eagles,Pennsylvania State Athletic Conference,2,CGE,CU,PACL,143
+Clark Atlanta Black Panthers,Clark Atlanta University,Black Panthers,Southern Intercollegiate Athletic Conference,2,CAU,CLA,GACL,144
+Clemson Tigers,Clemson University,Tigers,Atlantic Coast Conference,1A,CLM,CLE,SCCL,147
+Coast Guard Bears,United States Coast Guard Academy,Bears,New England Football Conference,3,CG,UCG,CTCG,722
+Coastal Carolina Chanticleers,Coastal Carolina University,Chanticleers,Big South Conference,1AA,CCU,COA,SCCC,149
+Coe Kohawks,Coe College,Kohawks,Iowa Intercollegiate Athletic Conference,3,COE,CC,IACO,150
+Colby Mules,Colby College,Mules,New England Small College Athletic Conference,3,CLB,CBY,MECO,151
+Colgate Raiders,Colgate University,Raiders,Patriot League,1AA,COL,CGT,NYCG,153
+College of Faith Saints,College of Faith,Saints,Independent,OTHER,CF,FAI,NCFT,506473
+College of Faith Warriors,College of Faith,Warriors,Independent,NAIA,COF,FAI,ARCF,506460
+College of Idaho Yotes,The College of Idaho,Yotes,Frontier Conference,NAIA,COI,CI,IDCO,500088
+Colorado Buffaloes,University of Colorado,Buffaloes,Pacific Twelve Conference,1A,CO,COL,COUN,157
+Colorado School of Mines Orediggers,Colorado School of Mines,Orediggers,Rocky Mountain Athletic Conference,2,CSM,COL,COMI,155
+Colorado State - Pueblo Thunderwolves,Colorado State U. - Pueblo,Thunderwolves,Rocky Mountain Athletic Conference,2,CSP,COL,COSO,2720
+Colorado State Rams,Colorado State University,Rams,Mountain West Conference,1A,CSU,COL,COST,156
+Columbia Lions,Columbia University,Lions,Ivy League,1AA,CUL,CU,NYCL,158
+Concord Mountain Lions,Concord University,Mountain Lions,Mountain East Conference,2,CND,CU,WVCO,1028
+Concordia Bulldogs,Concordia University,Bulldogs,Great Plains Athletic Conference,NAIA,CU,CNU,NECO,506061
+Concordia Cardinals,Concordia University,Cardinals,Mid-States Football Association,NAIA,CU,CO,MICO,501123
+Concordia Cobbers,Concordia College,Cobbers,Minnesota Intercollegiate Athletic Conference,3,CC,CNC,MNCO,161
+Concordia Cougars,Concordia University,Cougars,Northern Athletics Conference,3,CUC,CU,ILCT,160
+Concordia Falcons,Concordia University,Falcons,Northern Athletics Conference,3,CUF,CU,WICC,1036
+Concordia Golden Bears,Concordia University,Golden Bears,Northern Sun Intercollegiate Conference,2,CGB,CU,MNSP,9081
+Concordia Hornets,Concordia College-Selma,Hornets,Other,NAIA,CND,CCS,ALCO,506112
+Connecticut Huskies,University of Connecticut,Huskies,American Athletic Conference,1A,UCO,CND,CTUN,164
+Cornell Big Red,Cornell University,Big Red,Ivy League,1AA,COR,CRN,NYCN,167
+Cornell Rams,Cornell College,Rams,Midwest Conference,3,CCR,CRN,IACR,166
+Cortland Red Dragons,SUNY - College at Cortland,Red Dragons,Empire 8 Conference,3,SUN,SUC,NYCT,168
+Crown Storm,Crown College,Storm,Upper Midwest Athletic Conference,3,CRO,CWN,MNPB,30035
+Culver-Stockton Wildcats,Culver-Stockton College,Wildcats,Heart of America Athletic Conference,NAIA,CS,CSC,MOCS,506032
+Cumberland Bulldogs,Cumberland University,Bulldogs,Mid-South Conference,NAIA,CU,CUM,TNCC,501207
+Cumberlands Patriots,University of the Cumberlands,Patriots,Mid-South Conference,NAIA,CUM,UOC,KYCC,506101
+Curry Colonels,Curry College,Colonels,New England Football Conference,3,CUR,CRY,MACU,170
+Dakota State Trojans,Dakota State University,Trojans,North Star Athletic Association,NAIA,DAK,DS,SDDS,506066
+Dakota Wesleyan Tigers,Dakota Wesleyan University,Tigers,Great Plains Athletic Conference,NAIA,DW,DWU,SDWS,506033
+Dartmouth Big Green,Dartmouth College,Big Green,Ivy League,1AA,DAR,DRT,NHDA,172
+Davenport University,Davenport University,Panthers,Great Lakes Intercollegiate Athletic Conference,2,DVU,DVP,MIDA,30221
+Davidson Wildcats,Davidson College,Wildcats,Pioneer Football League,1AA,DAV,DVD,NCDA,173
+Dayton Flyers,University of Dayton,Flyers,Pioneer Football League,1AA,DAY,UD,OHDA,175
+Dean College,Dean College,Dean College,Northeast JC Football Conference,3,DC,DCB,MADE,30219
+Defiance Yellow Jackets,Defiance College,Yellow Jackets,Heartland Collegiate Athletic Conference,3,DEF,DC,OHDF,1050
+Delaware Blue Hens,University of Delaware,Blue Hens,Colonial Athletic Association,1AA,DE,DEL,DEUN,180
+Delaware State Hornets,Delaware State University,Hornets,Mid-Eastern Athletic Conference,1AA,DSU,DEL,DEST,178
+Delaware Valley Aggies,Delaware Valley College,Aggies,Middle Atlantic Conference,3,DVC,DEL,PADV,179
+Delta State Statesmen,Delta State University,Statesmen,Gulf South Conference,2,DEL,DSU,MSDE,181
+Denison Big Red,Denison University,Big Red,North Coast Athletic Conference,3,DEN,DU,OHDN,182
+DePauw Tigers,DePauw University,Tigers,North Coast Athletic Conference,3,DEP,DU,INDE,177
+Dickinson Blue Hawks,Dickinson State University,Blue Hawks,North Star Athletic Association,NAIA,DSU,DIC,NDDI,506123
+Dickinson Red Devils,Dickinson College,Red Devils,Centennial Conference,3,DIC,DC,PADI,185
+Dixie Red Storm,Dixie State College of Utah,Red Storm,Great Northwest Athletic Conference,2,DIX,DSC,UTDX,30095
+Doane Tigers,Doane College,Tigers,Great Plains Athletic Conference,NAIA,DO,DC,NEDO,30082
+Dordt Defenders,Dordt College,Defenders,Great Plains Athletic Conference,NAIA,DOR,DC,IADO,501390
+Drake Bulldogs,Drake University,Bulldogs,Pioneer Football League,1AA,DRA,DU,IADR,189
+Dubuque Spartans,University of Dubuque,Spartans,Iowa Intercollegiate Athletic Conference,3,DUB,UD,IADU,192
+Duke Blue Devils,Duke University,Blue Devils,Atlantic Coast Conference,1A,DUK,DU,NCDU,193
+Duquesne Dukes,Duquesne University,Dukes,Northeast Conference,1AA,DUQ,DU,PADU,194
+Earlham Quakers,Earlham College,Quakers,Heartland Collegiate Athletic Conference,3,EAR,EC,INEA,195
+East Carolina Pirates,East Carolina University,Pirates,American Athletic Conference,1A,ECU,EC,NCEA,196
+East Central Tigers,East Central University,Tigers,Great American Conference,2,ECT,EC,OKEC,8965
+East Stroudsburg Warriors,East Stroudsburg University,Warriors,Pennsylvania State Athletic Conference,2,ESU,ES,PAES,197
+East Tennessee Buccaneers,East Tennessee State University,Buccaneers,Independent,1AA,ETS,ETU,TNEA,198
+East Texas Baptist Tigers,East Texas Baptist University,Tigers,American Southwest Conference,3,ETB,ETU,TXBP,1062
+Eastern Illinois Panthers,Eastern Illinois University,Panthers,Ohio Valley Conference,1AA,EIU,EI,ILEA,201
+Eastern Kentucky Colonels,Eastern Kentucky University,Colonels,Ohio Valley Conference,1AA,EKU,EK,KYEA,202
+Eastern Michigan Eagles,Eastern Michigan University,Eagles,Mid-American Conference,1A,EMU,EM,MIEA,204
+Eastern New Mexico Greyhounds,Eastern New Mexico University,Greyhounds,Lone Star Conference,2,ENM,ENU,NMEA,206
+Eastern Oregon Mountaineers,Eastern Oregon University,Mountaineers,Frontier Conference,NAIA,EOU,EO,OREA,506406
+Eastern Washington Eagles,Eastern Washington University,Eagles,Big Sky Conference,1AA,EWU,EW,WAEA,207
+Edinboro Fighting Scots,Edinboro University,Fighting Scots,Pennsylvania State Athletic Conference,2,EU,EDI,PAED,209
+Edward Waters Tigers,Edward Waters College,Tigers,The Sun Conference,NAIA,EDW,EWC,FLEW,501555
+Elizabeth City Vikings,Elizabeth City State University,Vikings,Central Intercollegiate Athletic Association,2,ECS,EC,NCEC,210
+Elmhurst Blue Jays,Elmhurst College,Blue Jays,College Conference of Illinois and Wisconsin,3,ELM,EC,ILEL,212
+Elon Phoenix,Elon University,Phoenix,Colonial Athletic Association,1AA,ELO,ELN,NCEL,1068
+Emory & Henry Wasps,Emory & Henry College,Wasps,Old Dominion Athletic Conference,3,EHC,EMO,VAEH,216
+Emporia State Hornets,Emporia State University,Hornets,Mid-America Intercollegiate Athletic Association,2,ESH,EMP,KSTH,1071
+Endicott Gulls,Endicott College,Gulls,New England Football Conference,3,END,EC,MAEN,8981
+Eureka Red Devils,Eureka College,Red Devils,Upper Midwest Athletic Conference,3,EUR,EC,ILEU,218
+Evangel Crusaders,Evangel University,Crusaders,Heart of America Athletic Conference,NAIA,EVA,EU,MOEV,506080
+Fairleigh Dickinson-Florham Devils,Fairleigh Dickinson University-Florham,Devils,Middle Atlantic Conference,3,FDF,FDU,NJFD,221
+Fairmont State Fighting Falcons,Fairmont State College,Fighting Falcons,Mountain East Conference,2,FSC,FAI,WVFA,1076
+Faith Glory Eagles,University of Faith,Glory Eagles,Independent,OTHER,UF,FAI,FLFT,506485
+Faulkner Eagles,Faulkner University,Eagles,Mid-South Conference,NAIA,FU,FLK,ALFA,501659
+Fayetteville State Broncos,Fayetteville State University,Broncos,Central Intercollegiate Athletic Association,2,FAY,FSU,NCFA,223
+Ferris State Bulldogs,Ferris State University,Bulldogs,Great Lakes Intercollegiate Athletic Conference,2,FER,FSU,MIFE,224
+Ferrum Panthers,Ferrum College,Panthers,USA South Athletic Conference,3,FCP,FC,VAFC,225
+Findlay Oilers,University of Findlay,Oilers,Great Lakes Intercollegiate Athletic Conference,2,FIN,UF,OHFI,1079
+Finlandia Lions,Finlandia University,Lions,Independent,3,FUL,FU,MIFI,30032
+Fitchburg State Falcons,Fitchburg State College,Falcons,Massachusetts State College Athletic Conference,3,FIT,FSC,MAFI,227
+Florida A&M Rattlers,Florida A&M University,Rattlers,Mid-Eastern Athletic Conference,1AA,FAM,FL,FLAM,228
+Florida Atlantic Owls,Florida Atlantic University,Owls,Conference USA,1A,FAU,FL,FLAT,229
+Florida Gators,University of Florida,Gators,Southeastern Conference,1A,FL,FLO,FLUN,235
+Florida International Golden Panthers,Florida International University,Golden Panthers,Conference USA,1A,FIU,FL,FLIN,231
+Florida State Seminoles,Florida State University,Seminoles,Atlantic Coast Conference,1A,FSU,FL,FLST,234
+Florida Tech Panthers,Florida Institute of Technology,Panthers,Gulf South Conference,2,FT,FTU,FLTC,230
+Fordham Rams,Fordham University,Rams,Patriot League,1AA,FOR,FU,NYFO,236
+Fort Hays Tigers,Fort Hays State University,Tigers,Mid-America Intercollegiate Athletic Association,2,FH,FHS,KSFH,9011
+Fort Lewis Skyhawks,Fort Lewis College,Skyhawks,Rocky Mountain Athletic Conference,2,FLS,FLC,COFL,1083
+Fort Valley Wildcats,Fort Valley State University,Wildcats,Southern Intercollegiate Athletic Conference,2,FV,FVS,GAFV,237
+Framingham State Rams,Framingham State College,Rams,Massachusetts State College Athletic Conference,3,FRA,FSC,MAFR,238
+Franklin & Marshall Diplomats,Franklin & Marshall College,Diplomats,Centennial Conference,3,FM,FMC,PAFM,239
+Franklin Grizzlies,Franklin College,Grizzlies,Heartland Collegiate Athletic Conference,3,FCG,FRK,INFR,2694
+Fresno State Bulldogs,Fresno State University,Bulldogs,Mountain West Conference,1A,FSB,FRE,CAFR,96
+Friends Falcons,Friends University,Falcons,Kansas Collegiate Athletic Conference,NAIA,FRI,FU,KSFR,501826
+Frostburg State Bobcats,Frostburg State University,Bobcats,New Jersey Athletic Conference,3,FRO,FSU,MDFR,243
+Furman Paladins,Furman University,Paladins,Southern Conference,1AA,FUR,FU,SCFU,244
+Gallaudet Bison,Gallaudet University,Bison,Eastern Collegiate Football Conference,3,GAL,GU,DCGA,245
+Gannon Golden Knights,Gannon University,Golden Knights,Pennsylvania State Athletic Conference,2,GAN,GU,PAGA,246
+Gardner-Webb Runnin' Bulldogs,Gardner-Webb University,Runnin' Bulldogs,Big South Conference,1AA,GW,GWU,NCGW,1092
+Geneva Golden Tornadoes,Geneva College,Golden Tornadoes,Presidents Athletic Conference,3,GEN,GC,PAGN,30084
+George Fox Bruin,George Fox University,Bruin,Northwest Conference,3,GF,GFU,ORGF,1094
+Georgetown Hoyas,Georgetown University,Hoyas,Patriot League,1AA,GEO,GU,DCGT,251
+Georgetown Tigers,Georgetown College (Ky.),Tigers,Mid-South Conference,NAIA,GEO,GC,KYGT,506003
+Georgia Bulldogs,University of Georgia,Bulldogs,Southeastern Conference,1A,GA,GEO,GAUN,257
+Georgia Southern Eagles,Georgia Southern University,Eagles,Sun Belt Conference,1A,GS,GSU,GASO,253
+Georgia State Panthers,Georgia State University,Panthers,Sun Belt Conference,1A,GAS,GEO,GAST,254
+Georgia Tech Yellow Jackets,Georgia Institute of Technology,Yellow Jackets,Atlantic Coast Conference,1A,GIT,GA,GATC,255
+Gettysburg Bullets,Gettysburg College,Bullets,Centennial Conference,3,GET,GC,PAGB,258
+Glenville State Pioneers,Glenville State College,Pioneers,Mountain East Conference,2,GLE,GSC,WVGL,1098
+Grambling State Tigers,Grambling State University,Tigers,Southwestern Athletic Conference,1AA,GRA,GSU,LAGR,261
+Grand Valley State Lakers,Grand Valley State University,Lakers,Great Lakes Intercollegiate Athletic Conference,2,GV,GVS,MIGV,262
+Grand View Vikings,Grand View University,Vikings,Mid-States Football Association,NAIA,GV,GVU,IAGV,501982
+Greensboro Pride,Greensboro College,Pride,USA South Athletic Conference,3,GRE,GC,NCGR,263
+Greenville Panthers,Greenville College,Panthers,Upper Midwest Athletic Conference,3,GCP,GC,ILGV,1111
+Grinnell Pioneers,Grinnell College,Pioneers,Midwest Conference,3,GRI,GC,IAGN,264
+Grove City Wolverines,Grove City College,Wolverines,Presidents Athletic Conference,3,GRO,GCC,PAGC,265
+Guilford Quakers,Guilford College,Quakers,Old Dominion Athletic Conference,3,GUI,GC,NCGU,1112
+Gustavus Adolphus Golden Gusties,Gustavus Adolphus College,Golden Gusties,Minnesota Intercollegiate Athletic Conference,3,GUS,GAC,MNGA,266
+Hamilton Continentals,Hamilton College,Continentals,New England Small College Athletic Conference,3,HAC,HC,NYHA,267
+Hamline Pipers,Hamline University,Pipers,Minnesota Intercollegiate Athletic Conference,3,HAP,HU,MNHA,268
+Hampden-Sydney Tigers,Hampden-Sydney College,Tigers,Old Dominion Athletic Conference,3,HSC,HAM,VAHS,269
+Hampton Pirates,Hampton University,Pirates,Mid-Eastern Athletic Conference,1AA,HAM,HU,VAHI,270
+Hanover Panthers,Hanover College,Panthers,Heartland Collegiate Athletic Conference,3,HAN,HC,INHA,1115
+Hardin-Simmons Cowboys,Hardin-Simmons University,Cowboys,American Southwest Conference,3,HSU,HAR,TXHS,271
+Harding Bison,Harding University,Bison,Great American Conference,2,HRB,HU,ARHA,1116
+Hartwick Hawks,Hartwick College,Hawks,Empire 8 Conference,3,HRH,HC,NYHW,273
+Harvard Crimson,Harvard University,Crimson,Ivy League,1AA,HAR,HRV,MAHA,275
+Haskell Indians,Haskell Indian Nations University,Indians,Independent,NAIA,HAS,HIN,KSHA,506153
+Hastings Broncos,Hastings College,Broncos,Great Plains Athletic Conference,NAIA,HAS,HC,NEHA,30113
+Hawaii Warriors,University of Hawaii,Warriors,Mountain West Conference,1A,HI,HAW,HIUN,277
+Heidelberg Student Princes,Heidelberg College,Student Princes,Ohio Athletic Conference,3,HEI,HC,OHHE,278
+Henderson State Reddies,Henderson State University,Reddies,Great American Conference,2,HEN,HSU,ARHE,1123
+Hendrix Warriors,Hendrix College,Warriors,Southern Athletic Association,3,HCW,HC,ARHN,1124
+Hillsdale Chargers,Hillsdale College,Chargers,Great Lakes Intercollegiate Athletic Conference,2,HIL,HC,MIHI,280
+Hiram Terriers,Hiram College,Terriers,North Coast Athletic Conference,3,HIR,HC,OHHI,281
+Hobart Statesmen,Hobart and William Smith Colleges,Statesmen,Liberty League,3,HOB,HWS,NYHB,282
+Holy Cross Crusaders,College of the Holy Cross,Crusaders,Patriot League,1AA,HC,HOL,MAHC,285
+Hope Flying Dutchmen,Hope College,Flying Dutchmen,Michigan Intercollegiate Athletic Association,3,HOP,HC,MIHO,286
+Houston Baptist Huskies,Houston Baptist University,Huskies,Southland Conference,1AA,HBU,HB,TXHT,287
+Houston Cougars,University of Houston,Cougars,American Athletic Conference,1A,HOU,HST,TXHO,288
+Howard Bison,Howard University,Bison,Mid-Eastern Athletic Conference,1AA,HOW,HU,DCHO,290
+Howard Payne Yellow Jackets,Howard Payne University,Yellow Jackets,American Southwest Conference,3,HP,HPU,TXHP,2741
+Humboldt State Lumberjacks,Humboldt State University,Lumberjacks,Great Northwest Athletic Conference,2,HUM,HSU,CAHU,291
+Huntingdon Hawks,Huntingdon College,Hawks,USA South Athletic Conference,3,HUN,HC,ALHU,1130
+Husson Eagles,Husson University,Eagles,Eastern Collegiate Football Conference,3,HUS,HU,MEHU,1133
+Idaho State Bengals,Idaho State University,Bengals,Big Sky Conference,1AA,ISB,IDA,IDST,294
+Idaho Vandals,University of Idaho,Vandals,Sun Belt Conference,1A,ID,IDA,IDUN,295
+Illinois Blueboys,Illinois College,Blueboys,Midwest Conference,3,ILB,ILL,ILCL,297
+Illinois Fighting Illini,University of Illinois,Fighting Illini,Big Ten Conference,1A,IL,ILL,ILUN,301
+Illinois State Redbirds,Illinois State University,Redbirds,Missouri Valley Football Conference,1AA,ILS,ILL,ILST,299
+Illinois Wesleyan Titans,Illinois Wesleyan University,Titans,College Conference of Illinois and Wisconsin,3,IWU,ILL,ILWS,300
+Incarnate Word Cardinals,University of the Incarnate Word,Cardinals,Southland Conference,1AA,INC,UIW,TXIW,2743
+Indiana Hoosiers,Indiana University,Hoosiers,Big Ten Conference,1A,IN,IND,INUN,306
+Indiana State Sycamores,Indiana State University,Sycamores,Missouri Valley Football Conference,1AA,ISS,IND,INST,305
+Indiana University Crimson Hawks,Indiana University of Pennsylvania,Crimson Hawks,Pennsylvania State Athletic Conference,2,IUP,IND,PAIU,307
+Indianapolis Greyhounds,University of Indianapolis,Greyhounds,Great Lakes Valley Conference,2,IND,UI,INCE,309
+Iowa Hawkeyes,University of Iowa,Hawkeyes,Big Ten Conference,1A,IA,IOW,IAUN,312
+Iowa State Cyclones,Iowa State University,Cyclones,Big Twelve Conference,1A,ISU,IAS,IAST,311
+Iowa Wesleyan Tigers,Iowa Wesleyan College,Tigers,Upper Midwest Athletic Conference,3,IW,IWC,IAWS,30173
+Ithaca Bombers,Ithaca College,Bombers,Empire 8 Conference,3,ITH,IC,NYIT,313
+Jackson State Tigers,Jackson State University,Tigers,Southwestern Athletic Conference,1AA,JAC,JAX,MSJA,314
+Jacksonville Dolphins,Jacksonville University,Dolphins,Pioneer Football League,1AA,JXD,JAX,FLJA,316
+Jacksonville State Gamecocks,Jacksonville State University,Gamecocks,Ohio Valley Conference,1AA,JXS,JAX,ALJA,315
+James Madison Dukes,James Madison University,Dukes,Colonial Athletic Association,1AA,JMU,JAM,VAJM,317
+Jamestown Jimmies,University of Jamestown,Jimmies,North Star Athletic Association,NAIA,JAM,UJ,NDJA,506057
+John Carroll Blue Streaks,John Carroll University,Blue Streaks,Ohio Athletic Conference,3,JC,JCU,OHJC,320
+Johns Hopkins Blue Jays,Johns Hopkins University,Blue Jays,Centennial Conference,3,JH,JHU,MDJH,322
+Johnson C. Smith Golden Bulls,Johnson C. Smith University,Golden Bulls,Central Intercollegiate Athletic Association,2,JCS,JSU,NCJC,323
+Juniata Eagles,Juniata College,Eagles,Centennial Conference,3,JUN,JC,PAJU,325
+Kalamazoo Hornets,Kalamazoo College,Hornets,Michigan Intercollegiate Athletic Association,3,KAL,KC,MIKA,326
+Kansas Jayhawks,University of Kansas,Jayhawks,Big Twelve Conference,1A,KS,KAN,KSUN,328
+Kansas State Wildcats,Kansas State University,Wildcats,Big Twelve Conference,1A,KST,KAN,KSST,327
+Kansas Wesleyan Coyotes,Kansas Wesleyan University,Coyotes,Kansas Collegiate Athletic Conference,NAIA,KW,KWU,KSWS,506103
+Kean Cougars,Kean University,Cougars,New Jersey Athletic Conference,3,KU,KEA,NJKE,329
+Kennesaw State Owls,Kennesaw State University,Owls,Big South Conference,1AA,KSO,KSU,GAKS,1157
+Kent State Golden Flashes,Kent State University,Golden Flashes,Mid-American Conference,1A,KEN,KST,OHKS,331
+Kentucky Christian Knights,Kentucky Christian,Knights,Mid-South Conference,NAIA,KC,KCU,KYCH,502500
+Kentucky State Thorobreds,Kentucky State University,Thorobreds,Southern Intercollegiate Athletic Conference,2,KSU,KST,KYST,332
+Kentucky Wesleyan Panthers,Kentucky Wesleyan College,Panthers,Independent,2,KW,KWC,KYWS,333
+Kentucky Wildcats,University of Kentucky,Wildcats,Southeastern Conference,1A,KY,KEN,KYUN,334
+Kenyon Lords,Kenyon College,Lords,North Coast Athletic Conference,3,KCL,KNY,OHKE,335
+King's Monarchs,King's College,Monarchs,Middle Atlantic Conference,3,KC,KIN,PAKI,336
+Kings Point Mariners,United States Merchant Marine Academy,Mariners,Liberty League,3,MMA,KP,NYMM,724
+Knox Prairie Fire,Knox College,Prairie Fire,Midwest Conference,3,KNX,KNO,ILKN,337
+Kutztown Golden Bears,Kutztown University,Golden Bears,Pennsylvania State Athletic Conference,2,KUT,KU,PAKU,339
+Lafayette Leopards,Lafayette College,Leopards,Patriot League,1AA,LAF,LAY,PALF,342
+LaGrange Panthers,LaGrange College,Panthers,USA South Athletic Conference,3,LC,LAG,GALA,1162
+Lake Erie Storm,Lake Erie College,Storm,Great Lakes Intercollegiate Athletic Conference,2,LE,LEC,OHLE,2746
+Lake Forest Foresters,Lake Forest College,Foresters,Midwest Conference,3,LFC,LAF,ILLF,344
+Lakeland Muskies,Lakeland College,Muskies,Northern Athletics Conference,3,LAK,LC,WILK,1164
+Lamar Cardinals,Lamar University,Cardinals,Southland Conference,1AA,LAM,LU,TXLA,346
+Lane Dragons,Lane College,Dragons,Southern Intercollegiate Athletic Conference,2,LAN,LNE,TNLA,347
+Langston Lions,Langston University,Lions,Central States Football League,NAIA,LAN,LU,OKLA,506054
+LaVerne Leopards,University of LaVerne,Leopards,Southern California Intercollegiate Athletic Conf.,3,LAV,UL,CALV,341
+Lawrence Vikings,Lawrence University,Vikings,Midwest Conference,3,LAW,LU,WILW,348
+Lebanon Valley Dutchmen,Lebanon Valley College,Dutchmen,Middle Atlantic Conference,3,LV,LVC,PALV,351
+Lehigh Mountain Hawks,Lehigh University,Mountain Hawks,Patriot League,1AA,LEH,LU,PALE,352
+Lenoir-Rhyne Bears,Lenoir-Rhyne College,Bears,South Atlantic Conference,2,LRC,LEN,NCLR,1170
+Lewis & Clark Pioneers,Lewis & Clark College,Pioneers,Northwest Conference,3,LCP,LCC,ORLC,22235
+Liberty Flames,Liberty University,Flames,Big South Conference,1AA,LIB,LU,VALB,355
+Limestone Saints,Limestone College,Saints,Independent,2,LIM,LC,SCLC,1174
+Lincoln Blue Tigers,Lincoln University of Missouri,Blue Tigers,Great Lakes Valley Conference,2,LIN,LUM,MOLN,356
+Lincoln Lions,Lincoln University (Pa.),Lions,Central Intercollegiate Athletic Association,2,LCN,LU,PALN,357
+Lindenwood Lions,Lindenwood University,Lions,Mid-America Intercollegiate Athletic Association,2,LUL,LU,MOLW,30136
+Lindenwood Lynx,Lindenwood University - Belleville,Lynx,Independent,NAIA,LIN,LUB,ILLB,506373
+Lindsey Wilson Blue Raiders,Lindsey Wilson College,Blue Raiders,Mid-South Conference,NAIA,LW,LWC,KYLW,502727
+Linfield Wildcats,Linfield College,Wildcats,Northwest Conference,3,LNW,LC,ORLI,1179
+Livingstone Blue Bears,Livingstone College,Blue Bears,Central Intercollegiate Athletic Association,2,LIV,LC,NCLI,359
+Lock Haven Bald Eagles,Lock Haven University,Bald Eagles,Pennsylvania State Athletic Conference,2,LH,LHU,PALH,360
+Long Island University Pioneers,Long Island University-C.W. Post,Pioneers,Northeast-10 Conference,2,LIU,CWP,NYCW,362
+Loras Duhawks,Loras College,Duhawks,Iowa Intercollegiate Athletic Conference,3,LOR,LC,IALO,364
+Louisiana State Fighting Tigers,Louisiana State University,Fighting Tigers,Southeastern Conference,1A,LSU,LOU,LAST,365
+Louisiana Tech Bulldogs,Louisiana Tech University,Bulldogs,Conference USA,1A,LTU,LOU,LATC,366
+Louisiana Wildcats,Louisiana College,Wildcats,American Southwest Conference,3,LCW,LSC,LALC,1182
+Louisiana-Lafayette Ragin Cajuns,University of Louisiana-Lafayette,Ragin Cajuns,Sun Belt Conference,1A,ULL,LL,LASW,671
+Louisiana-Monroe Warhawks,University of Louisiana-Monroe,Warhawks,Sun Belt Conference,1A,ULM,LM,LANE,498
+Louisville Cardinals,University of Louisville,Cardinals,Atlantic Coast Conference,1A,LOU,UL,KYLO,367
+Luther Norse,Luther College,Norse,Iowa Intercollegiate Athletic Conference,3,LUT,LC,IALU,372
+Lycoming Warriors,Lycoming College,Warriors,Middle Atlantic Conference,3,LYC,LC,PALY,373
+Macalester Scots,Macalester College,Scots,Midwest Conference,3,MAC,MC,MNMC,376
+MacMurray Highlanders,MacMurray College,Highlanders,Upper Midwest Athletic Conference,3,MCH,MC,ILMC,377
+Maine Black Bears,University of Maine,Black Bears,Colonial Athletic Association,1AA,ME,UM,MEUN,380
+Maine Maritime Mariners,Maine Maritime Academy,Mariners,New England Football Conference,3,MMM,MAI,MEMA,378
+Malone Pioneers,Malone University,Pioneers,Great Lakes Intercollegiate Athletic Conference,2,MAL,MU,OHML,30137
+Manchester Spartans,Manchester College,Spartans,Heartland Collegiate Athletic Conference,3,MAN,MC,INMA,1192
+Maranatha Crusaders,Maranatha Baptist College,Crusaders,Independent,3,MCC,MBC,WIMR,1194
+Marian Knights,Marian University,Knights,Mid-States Football Association,NAIA,MAR,MU,INMC,502945
+Marietta Pioneers,Marietta College,Pioneers,Ohio Athletic Conference,3,MAP,MC,OHMA,385
+Marist Red Foxes,Marist College,Red Foxes,Pioneer Football League,1AA,MCR,MC,NYMR,386
+Maritime Privateers,SUNY - Maritime College,Privateers,Eastern Collegiate Football Conference,3,SMC,MC,NYMA,478
+Mars Hill Lions,Mars Hill College,Lions,South Atlantic Conference,2,MHC,MAR,NCMH,1199
+Marshall Thundering Herd,Marshall University,Thundering Herd,Conference USA,1A,MAR,MU,WVMA,388
+Martin Luther Knights,Martin Luther College,Knights,Upper Midwest Athletic Conference,3,ML,MLC,MNML,8597
+Mary Hardin-Baylor Crusaders,University of Mary Hardin-Baylor,Crusaders,American Southwest Conference,3,MHB,MAR,TXHB,1203
+Mary Marauders,University of Mary,Marauders,Northern Sun Intercollegiate Conference,2,UMM,UM,NDMY,30075
+Maryland Terrapins,University of Maryland,Terrapins,Big Ten Conference,1A,MD,MAR,MDUN,392
+Maryville Scots,Maryville College,Scots,USA South Athletic Conference,3,MSC,MC,TNMA,396
+Massachusetts Institute of Technology Engineers,Massachusetts Institute of Technology,Engineers,New England Football Conference,3,MIT,MAS,MATC,398
+Massachusetts Maritime Buccaneers,Massachusetts Maritime Academy,Buccaneers,Massachusetts State College Athletic Conference,3,MMB,MM,MAMA,399
+Massachusetts Minutemen,University of Massachusetts,Minutemen,Mid-American Conference,1A,MA,UM,MAUN,400
+Mayville State Comets,Mayville State University,Comets,North Star Athletic Association,NAIA,MSU,MAY,NDMA,502225
+McDaniel Green Terror,McDaniel College,Green Terror,Centennial Conference,3,MCD,MDC,MDWE,773
+McKendree Bearcats,McKendree College,Bearcats,Great Lakes Valley Conference,2,MCK,MC,ILMK,30138
+McMurry War Hawks,McMurry University,War Hawks,American Southwest Conference,3,MCM,MU,TXMC,8530
+McNeese State Cowboys,McNeese State University,Cowboys,Southland Conference,1AA,MCN,MSU,LAMC,402
+McPherson Bulldogs,McPherson College,Bulldogs,Kansas Collegiate Athletic Conference,NAIA,MCP,MC,KSMC,506039
+Memphis Tigers,University of Memphis,Tigers,American Athletic Conference,1A,MEM,UM,TNMS,404
+Menlo Oaks,Menlo College,Oaks,Independent,NAIA,MEN,MC,CAME,506392
+Mercer Bears,Mercer University,Bears,Southern Conference,1AA,MER,MU,GAME,406
+Mercyhurst Lakers,Mercyhurst College,Lakers,Pennsylvania State Athletic Conference,2,MCL,MCY,PAME,408
+Merrimack Warriors,Merrimack College,Warriors,Northeast-10 Conference,2,MCW,MC,MAMK,410
+Mesa State Mavericks,Mesa State College,Mavericks,Rocky Mountain Athletic Conference,2,MES,MSC,COME,11416
+Methodist Monarchs,Methodist University,Monarchs,USA South Athletic Conference,3,MET,MU,NCME,412
+Miami Hurricanes,University of Miami (Fla.),Hurricanes,Atlantic Coast Conference,1A,MIA,U,FLMI,415
+Miami Redhawks,Miami University (Ohio),Redhawks,Mid-American Conference,1A,MIO,MOH,OHMI,414
+Michigan State Spartans,Michigan State University,Spartans,Big Ten Conference,1A,MIC,MST,MIST,416
+Michigan Technological Huskies,Michigan Technological University,Huskies,Great Lakes Intercollegiate Athletic Conference,2,MTU,MIC,MITC,417
+Michigan Wolverines,University of Michigan,Wolverines,Big Ten Conference,1A,MI,MIC,MIUN,418
+Middle Tennessee Blue Raiders,Middle Tennessee State University,Blue Raiders,Conference USA,1A,MTS,MID,TNMI,419
+Middlebury Panthers,Middlebury College,Panthers,New England Small College Athletic Conference,3,MDB,MC,VTMI,420
+Midland Warriors,Midland University,Warriors,Great Plains Athletic Conference,NAIA,MID,MU,NELU,506060
+Midwestern State Mustangs,Midwestern State University,Mustangs,Lone Star Conference,2,MID,MWS,TXMW,1222
+Miles Golden Bears,Miles College,Golden Bears,Southern Intercollegiate Athletic Conference,2,MIL,MC,ALMI,422
+Millersville Marauders,Millersville University,Marauders,Pennsylvania State Athletic Conference,2,MUM,MU,PAMI,423
+Millikin Big Blue,Millikin University,Big Blue,College Conference of Illinois and Wisconsin,3,MLB,MU,ILMI,424
+Millsaps Majors,Millsaps College,Majors,Southern Athletic Association,3,MLS,MC,MSMI,426
+Minnesota Golden Gophers,University of Minnesota,Golden Gophers,Big Ten Conference,1A,MN,MIN,MNUN,428
+Minnesota State Dragons,Minnesota State University-Moorhead,Dragons,Northern Sun Intercollegiate Conference,2,MSD,MIN,MNMH,1240
+Minnesota State-Mankato Mavericks,Minnesota State University-Mankato,Mavericks,Northern Sun Intercollegiate Conference,2,MIN,MSM,MNMA,383
+Minnesota-Crookston Golden Eagles,University of Minnesota-Crookston,Golden Eagles,Northern Sun Intercollegiate Conference,2,MC,MIN,MNCR,27854
+Minnesota-Duluth Bulldogs,University of Minnesota-Duluth,Bulldogs,Northern Sun Intercollegiate Conference,2,UMD,MD,MNDU,427
+Minnesota-Morris Cougars,University of Minnesota-Morris,Cougars,Upper Midwest Athletic Conference,3,MIM,MIN,MNMS,1226
+Minot Beavers,Minot State University,Beavers,Northern Sun Intercollegiate Conference,2,MUB,MU,NDMI,30125
+Misericordia Cougars,Misericordia University,Cougars,Middle Atlantic Conference,3,MUC,MU,PAMS,16142
+Mississippi Choctaws,Mississippi College,Choctaws,Gulf South Conference,2,MIS,MC,MSCO,429
+Mississippi Rebels,University of Mississippi,Rebels,Southeastern Conference,1A,MS,MIS,MSUN,433
+Mississippi State Bulldogs,Mississippi State University,Bulldogs,Southeastern Conference,1A,MST,MIS,MSST,430
+Mississippi Valley Delta Devils,Mississippi Valley State University,Delta Devils,Southwestern Athletic Conference,1AA,MVS,MIS,MSVA,432
+Missouri Baptist Spartans,Missouri Baptist University,Spartans,Independent,NAIA,LIM,LC,MOBP,503262
+Missouri S&T Miners,Missouri University of Science and Technology,Miners,Great Lakes Valley Conference,2,MSM,MO,MORO,435
+Missouri Southern Lions,Missouri Southern State University,Lions,Mid-America Intercollegiate Athletic Association,2,MSS,MOS,MOSO,9012
+Missouri State Bears,Missouri State University,Bears,Missouri Valley Football Conference,1AA,MSU,MOS,MOSW,669
+Missouri Tigers,University of Missouri,Tigers,Southeastern Conference,1A,MO,MIS,MOUN,434
+Missouri Valley Vikings,Missouri Valley College,Vikings,Heart of America Athletic Conference,NAIA,MV,MVC,MOVA,506068
+Missouri Western Griffons,Missouri Western State University,Griffons,Mid-America Intercollegiate Athletic Association,2,MWS,MIS,MOWE,9013
+Monmouth Fighting Scots,Monmouth College,Fighting Scots,Midwest Conference,3,MCS,MC,ILMO,438
+Monmouth Hawks,Monmouth University,Hawks,Big South Conference,1AA,MON,MU,NJMO,439
+Montana - Western Bulldogs,University of Montana - Western,Bulldogs,Frontier Conference,NAIA,UMW,MON,MTWE,506024
+Montana Grizzlies,University of Montana,Grizzlies,Big Sky Conference,1AA,MTG,MON,MTUN,441
+Montana State Fighting Bobcats,Montana State University,Fighting Bobcats,Big Sky Conference,1AA,MSB,MSU,MTST,440
+Montana State Northern Lights,Montana State University-Northern,Lights,Frontier Conference,NAIA,MSN,MS,MTSN,503735
+Montana Tech Orediggers,Montana Tech,Orediggers,Frontier Conference,NAIA,MT,MTU,MTCL,506022
+Montclair State Red Hawks,Montclair State University,Red Hawks,New Jersey Athletic Conference,3,MSR,MON,NJMC,442
+Moravian Greyhounds,Moravian College,Greyhounds,Centennial Conference,3,MOG,MC,PAMO,443
+Morehead State Eagles,Morehead State University,Eagles,Pioneer Football League,1AA,MSE,MOR,KYMO,444
+Morehouse Maroon Tigers,Morehouse College,Maroon Tigers,Southern Intercollegiate Athletic Conference,2,MMT,MC,GAMH,445
+Morgan State Bears,Morgan State University,Bears,Mid-Eastern Athletic Conference,1AA,MOR,MSU,MDMO,446
+Morningside Mustangs,Morningside College,Mustangs,Great Plains Athletic Conference,NAIA,MOR,MRN,IAMO,506400
+Morrisville State Mustangs,Morrisville State College,Mustangs,Empire 8 Conference,3,MRS,MSU,NYMO,30067
+Mount Ida Mustangs,Mount Ida College,Mustangs,Eastern Collegiate Football Conference,3,MTM,MIC,MAMI,27901
+Mount St. Joseph Lions,College of Mount St. Joseph,Lions,Heartland Collegiate Athletic Conference,3,MSJ,MOU,OHSJ,8567
+Mount Union Purple Raiders,Mount Union College,Purple Raiders,Ohio Athletic Conference,3,MU,MUC,OHMT,452
+Muhlenberg Mules,Muhlenberg College,Mules,Centennial Conference,3,MUH,MC,PAMU,453
+Murray State Racers,Murray State University,Racers,Ohio Valley Conference,1AA,MUR,MSU,KYMU,454
+Muskingum Fighting Muskies,Muskingum College,Fighting Muskies,Ohio Athletic Conference,3,MUS,MC,OHMS,455
+Navy Midshipmen,United States Naval Academy,Midshipmen,American Athletic Conference,1A,NVY,NAV,MDNA,726
+Nebraska Cornhuskers,University of Nebraska,Cornhuskers,Big Ten Conference,1A,NE,NEB,NEUN,463
+Nebraska Wesleyan Prairie Wolves,Nebraska Wesleyan University,Prairie Wolves,Great Plains Athletic Conference,NAIA,NW,NWU,NEWS,462
+Nebraska-Kearney Lopers,University of Nebraska-Kearney,Lopers,Mid-America Intercollegiate Athletic Association,2,UNK,NEB,NEKE,1156
+Nevada Wolfpack,University of Nevada,Wolfpack,Mountain West Conference,1A,NV,NEV,NVRE,466
+Nevada-Las Vegas Rebels,University of Nevada-Las Vegas,Rebels,Mountain West Conference,1A,NLV,NEV,NVLV,465
+New England Nor'Easters,University Of New England,Nor'Easters,New England Football Conference,3,UNE,NRE,MENE,1255
+New Hampshire Wildcats,University of New Hampshire,Wildcats,Colonial Athletic Association,1AA,NH,NHA,NHUN,469
+New Haven Chargers,University of New Haven,Chargers,Northeast-10 Conference,2,UNH,NH,CTNH,470
+New Jersey Lions,College of New Jersey,Lions,New Jersey Athletic Conference,3,CNJ,NJ,NJTR,712
+New Mexico Highlands Cowboys,New Mexico Highlands University,Cowboys,Rocky Mountain Athletic Conference,2,NMH,NM,NMHI,8577
+New Mexico Lobos,University of New Mexico,Lobos,Mountain West Conference,1A,NM,UNM,NMUN,473
+New Mexico State Aggies,New Mexico State University,Aggies,Sun Belt Conference,1A,NMS,NM,NMST,472
+Newberry Wolves,Newberry College,Wolves,South Atlantic Conference,2,NEW,NBY,SCNE,1257
+Nicholls State Colonels,Nicholls State University,Colonels,Southland Conference,1AA,NIC,NSU,LANI,483
+Nichols Bison,Nichols College,Bison,New England Football Conference,3,NCB,NC,MANI,484
+Norfolk State Spartans,Norfolk State University,Spartans,Mid-Eastern Athletic Conference,1AA,NOR,NSU,VANO,485
+North Alabama Lions,University of North Alabama,Lions,Gulf South Conference,2,,NAL,ALNO,487
+North Carolina A&T Aggies,North Carolina A&T State University,Aggies,Mid-Eastern Athletic Conference,1AA,NCA,NCT,NCAT,488
+North Carolina at Pembroke Braves,University of North Carolina at Pembroke,Braves,Independent,2,NCP,NC,NCPM,537
+North Carolina Central Eagles,North Carolina Central University,Eagles,Mid-Eastern Athletic Conference,1AA,NCE,NCU,NCCE,489
+North Carolina State Wolfpack,North Carolina State University,Wolfpack,Atlantic Coast Conference,1A,NCS,NC,NCST,490
+North Carolina Tar Heels,University of North Carolina,Tar Heels,Atlantic Coast Conference,1A,NC,UNC,NCUN,457
+North Carolina Wesleyan Battling Bishops,North Carolina Wesleyan College,Battling Bishops,USA South Athletic Conference,3,NCW,NC,NCWC,491
+North Central Cardinals,North Central College,Cardinals,College Conference of Illinois and Wisconsin,3,NCR,NOR,ILNC,492
+North Dakota Fighting Sioux,University of North Dakota,Fighting Sioux,Big Sky Conference,1AA,NDF,NDA,NDUN,494
+North Dakota State Bison,North Dakota State University,Bison,Missouri Valley Football Conference,1AA,NDS,ND,NDST,493
+North Greenville Crusaders,North Greenville University,Crusaders,Independent,2,NGU,NOG,SCNG,9223
+North Park Vikings,North Park University,Vikings,College Conference of Illinois and Wisconsin,3,NP,NPU,ILNP,496
+North Texas Mean Green,University of North Texas,Mean Green,Conference USA,1A,UNT,NT,TXNO,497
+Northeastern Riverhawks,Northeastern State University,Riverhawks,Mid-America Intercollegiate Athletic Association,2,NER,NES,OKNE,12810
+Northern Arizona Lumberjacks,Northern Arizona University,Lumberjacks,Big Sky Conference,1AA,NAU,,AZNO,501
+Northern Colorado Bears,University of Northern Colorado,Bears,Big Sky Conference,1AA,UNC,NOC,CONO,502
+Northern Illinois Huskies,Northern Illinois University,Huskies,Mid-American Conference,1A,NIL,NIU,ILNO,503
+Northern Iowa Panthers,University of Northern Iowa,Panthers,Missouri Valley Football Conference,1AA,UNI,NI,IANO,504
+Northern Michigan Wildcats,Northern Michigan University,Wildcats,Great Lakes Intercollegiate Athletic Conference,2,NMU,NM,MINO,506
+Northern State Wolves,Northern State University,Wolves,Northern Sun Intercollegiate Conference,2,NSU,NS,SDNO,1266
+Northwest Missouri Bearcats,Northwest Missouri State University,Bearcats,Mid-America Intercollegiate Athletic Association,2,NWM,NMS,MONW,507
+Northwestern Eagles,University of Northwestern,Eagles,Upper Midwest Athletic Conference,3,NWE,UNW,MNNW,30031
+Northwestern Oklahoma Rangers,Northwestern Oklahoma State University,Rangers,Great American Conference,2,NWO,NOS,OKNW,30178
+Northwestern Red Raiders,Northwestern College,Red Raiders,Great Plains Athletic Conference,NAIA,NW,NWC,IANW,506072
+Northwestern State Demons,Northwestern State University,Demons,Southland Conference,1AA,NWS,NW,LANW,508
+Northwestern Wildcats,Northwestern University,Wildcats,Big Ten Conference,1A,NW,NWU,ILNW,509
+Northwood Timberwolves,Northwood University,Timberwolves,Great Lakes Intercollegiate Athletic Conference,2,NWT,NWU,MINW,510
+Norwich Cadets,Norwich University,Cadets,Eastern Collegiate Football Conference,3,NUC,NU,VTNO,511
+Notre Dame Falcons,Notre Dame College,Falcons,Mountain East Conference,2,NDC,ND,OHND,30126
+Notre Dame Fighting Irish,University of Notre Dame,Fighting Irish,Independent,1A,ND,UND,INND,513
+Oberlin Yeomen,Oberlin College,Yeomen,North Coast Athletic Conference,3,OBE,OC,OHOB,515
+Occidental Tigers,Occidental College,Tigers,Southern California Intercollegiate Athletic Conf.,3,OCC,OC,CAOC,516
+Ohio Bobcats,Ohio University,Bobcats,Mid-American Conference,1A,OU,OHU,OHUN,519
+Ohio Dominican Panthers,Ohio Dominican University,Panthers,Great Lakes Intercollegiate Athletic Conference,2,ODU,OD,OHDO,30119
+Ohio Northern Polar Bears,Ohio Northern University,Polar Bears,Ohio Athletic Conference,3,ONU,OHN,OHNO,517
+Ohio State Buckeyes,Ohio State University,Buckeyes,Big Ten Conference,1A,OSU,OS,OHST,518
+Ohio Wesleyan Battling Bishops,Ohio Wesleyan University,Battling Bishops,North Coast Athletic Conference,3,OWU,OW,OHWS,520
+Oklahoma Baptist Bison,Oklahoma Baptist University,Bison,Great American Conference,2,OB,OBU,OKBP,30202
+Oklahoma Panhandle Aggies,Oklahoma Panhandle State University,Aggies,Independent,2,OPS,OP,OKPH,506515
+Oklahoma Sooners,University of Oklahoma,Sooners,Big Twelve Conference,1A,OK,UOK,OKUN,522
+Oklahoma State Cowboys,Oklahoma State University,Cowboys,Big Twelve Conference,1A,OKC,OKS,OKST,521
+Old Dominion Monarchs,Old Dominion University,Monarchs,Conference USA,1A,OLD,ODU,VAOD,523
+Olivet Comets,Olivet College,Comets,Michigan Intercollegiate Athletic Association,3,OLI,OC,MIOL,525
+Olivet Nazarene Tigers,Olivet Nazarene University,Tigers,Mid-States Football Association,NAIA,ON,ONU,ILOL,506045
+Oregon Ducks,University of Oregon,Ducks,Pacific Twelve Conference,1A,OR,ORE,ORUN,529
+Oregon State Beavers,Oregon State University,Beavers,Pacific Twelve Conference,1A,ORE,OSU,ORST,528
+Ottawa Braves,Ottawa University,Braves,Kansas Collegiate Athletic Conference,NAIA,OTT,OU,KSOT,506046
+Otterbein Otters,Otterbein College,Otters,Ohio Athletic Conference,3,OTT,OC,OHOT,531
+Ouachita Tigers,Ouachita Baptist University,Tigers,Great American Conference,2,OUA,OBU,AROU,1289
+Pace Settlers,Pace University,Settlers,Northeast-10 Conference,2,PAC,PU,NYPA,533
+Pacific Boxers,Pacific University,Boxers,Northwest Conference,3,PUB,PCU,ORPA,2751
+Pacific Lutheran Lutes,Pacific Lutheran University,Lutes,Northwest Conference,3,PLU,PL,WAPL,1297
+Paine Lions,Paine College,Lions,Southern Intercollegiate Athletic Conference,2,PC,PAI,GAPA,535
+Penn State Nittany Lions,Penn State University,Nittany Lions,Big Ten Conference,1A,PSU,PEN,PAST,539
+Pennsylvania Quakers,University of Pennsylvania,Quakers,Ivy League,1AA,PA,PEN,PAUN,540
+Phoenix Bears,Phoenix College,Bears,Western States Football Conference,NJCAA,PHX,PHO,AZPH,506470
+Pikeville Bears,University of Pikeville,Bears,Mid-South Conference,NAIA,PIK,UP,KYPV,504135
+Pittsburg State Gorillas,Pittsburg State University,Gorillas,Mid-America Intercollegiate Athletic Association,2,PSG,PSU,KSPS,1314
+Pittsburgh Panthers,University of Pittsburgh,Panthers,Atlantic Coast Conference,1A,PIT,UP,PAPT,545
+Plymouth State Panthers,Plymouth State College,Panthers,Massachusetts State College Athletic Conference,3,PS,PSC,NHPL,548
+Point Skyhawks,Point University,Skyhawks,Independent,NAIA,PU,POI,GAPT,500270
+Pomona-Pitzer Sagehens,Pomona-Pitzer Colleges,Sagehens,Southern California Intercollegiate Athletic Conf.,3,PPC,POP,CAPZ,549
+Portland State Vikings,Portland State University,Vikings,Big Sky Conference,1AA,PSV,POR,ORPS,550
+Prairie View A&M Panthers,Prairie View A&M University,Panthers,Southwestern Athletic Conference,1AA,PV,PVA,TXPV,553
+Presbyterian Blue Hose,Presbyterian College,Blue Hose,Big South Conference,1AA,PRE,PC,SCPR,1320
+Presentation Saints,Presentation College,Saints,North Star Athletic Association,NAIA,PC,PRE,SDPR,504212
+Princeton Tigers,Princeton University,Tigers,Ivy League,1AA,PRI,PU,NJPR,554
+Puget Sound Loggers,University of Puget Sound,Loggers,Northwest Conference,3,PG,UPG,WAPU,557
+Purdue Boilermakers,Purdue University,Boilermakers,Big Ten Conference,1A,PUR,PU,INPU,559
+Quincy Hawks,Quincy University,Hawks,Great Lakes Valley Conference,2,QUI,QUN,ILQU,561
+Randolph-Macon Yellow Jackets,Randolph-Macon College,Yellow Jackets,Old Dominion Athletic Conference,3,RM,RMC,VARM,565
+Redlands Bulldogs,University of Redlands,Bulldogs,Southern California Intercollegiate Athletic Conf.,3,RDB,UR,CARE,567
+Reinhardt Eagles,Reinhardt University,Eagles,Mid-South Conference,NAIA,REI,RU,GARE,506141
+Rhode Island Rams,University of Rhode Island,Rams,Colonial Athletic Association,1AA,RI,URI,RIUN,572
+Rhodes Lynx,Rhodes College,Lynx,Southern Athletic Association,3,RHO,RC,TNSW,573
+Rice Owls,Rice University,Owls,Conference USA,1A,RIC,RU,TXRI,574
+Richmond Spiders,University of Richmond,Spiders,Colonial Athletic Association,1AA,RIS,UR,VARI,575
+Ripon Red Hawks,Ripon College,Red Hawks,Midwest Conference,3,RIP,RC,WIRI,577
+Robert Morris Colonials,Robert Morris University,Colonials,Northeast Conference,1AA,RMU,ROB,PARM,579
+Robert Morris Eagles,Robert Morris University,Eagles,Mid-States Football Association,NAIA,RMU,ROB,ILRM,504364
+Rochester Yellowjackets,University of Rochester,Yellowjackets,Liberty League,3,ROC,RCH,NYRU,581
+Rockford Regents,Rockford College,Regents,Northern Athletics Conference,3,RCR,RC,ILRF,582
+Rocky Mountain Battlin' Bears,Rocky Mountain College,Battlin' Bears,Frontier Conference,NAIA,RM,RMC,MTRM,506025
+Rose-Hulman Fightin' Engineers,Rose-Hulman Institute of Technology,Fightin' Engineers,Heartland Collegiate Athletic Conference,3,RH,ROS,INRH,585
+Rowan Profs,Rowan University,Profs,New Jersey Athletic Conference,3,ROW,RU,NJGL,259
+RPI Engineers,Rensselaer Polytechnic Institute,Engineers,Liberty League,3,RPI,REN,NYRE,570
+Rutgers Scarlet Knights,Rutgers University,Scarlet Knights,Big Ten Conference,1A,RUT,RU,NJRU,587
+Sacred Heart Pioneers,Sacred Heart University,Pioneers,Northeast Conference,1AA,SH,SAC,CTSH,590
+Saginaw Valley State Cardinals,Saginaw Valley State University,Cardinals,Great Lakes Intercollegiate Athletic Conference,2,SAG,SVS,MISV,591
+Saint Anselm Hawks,St. Anselm College,Hawks,Northeast-10 Conference,2,SAC,SA,NHSA,593
+Saint Augustine's Mighty Falcons,Saint Augustine's College,Mighty Falcons,Central Intercollegiate Athletic Association,2,SA,SAC,NCSA,594
+Saint Francis Red Flash,Saint Francis University,Red Flash,Northeast Conference,1AA,SF,SFU,PASF,600
+Saint Mary Spires,University of Saint Mary,Spires,Kansas Collegiate Athletic Conference,NAIA,SM,USM,KSSM,506064
+Saint Vincent Bearcats,Saint Vincent College,Bearcats,Presidents Athletic Conference,3,SV,SVU,PASV,30064
+Saint Xavier Cougars,Saint Xavier University,Cougars,Mid-States Football Association,NAIA,SX,SXU,ILSX,504660
+Salisbury Sea Gulls,Salisbury State University,Sea Gulls,New Jersey Athletic Conference,3,SAL,SSU,MDSA,622
+Salve Regina Seahawks,Salve Regina University,Seahawks,New England Football Conference,3,SR,SAL,RISR,623
+Sam Houston State Bearkats,Sam Houston State University,Bearkats,Southland Conference,1AA,SHS,SAM,TXSH,624
+Samford Bulldogs,Samford University,Bulldogs,Southern Conference,1AA,SAM,SMF,ALSM,625
+San Diego State Aztecs,San Diego State University,Aztecs,Mountain West Conference,1A,SDS,SD,CASS,626
+San Diego Toreros,University of San Diego,Toreros,Pioneer Football League,1AA,SD,USD,CASU,627
+San Jose State Spartans,San Jose State University,Spartans,Mountain West Conference,1A,SJS,SJ,CASJ,630
+Savannah State Tigers,Savannah State University,Tigers,Mid-Eastern Athletic Conference,1AA,SAV,SSU,GASA,632
+Seton Hill Griffins,Seton Hill University,Griffins,Pennsylvania State Athletic Conference,2,SHG,SET,PASE,30063
+Sewanee Tigers,The University of the South,Tigers,Southern Athletic Association,3,SEW,TUS,TNUS,652
+Shaw Bears,Shaw University,Bears,Central Intercollegiate Athletic Association,2,SHA,SU,NCSH,636
+Shenandoah Hornets,Shenandoah University,Hornets,Old Dominion Athletic Conference,3,SHE,SU,VASU,637
+Shepherd Rams,Shepherd University,Rams,Mountain East Conference,2,SHP,SU,WVSH,10870
+Shippensburg Raiders,Shippensburg University,Raiders,Pennsylvania State Athletic Conference,2,SU,SHI,PASH,638
+Shorter Hawks,Shorter University,Hawks,Gulf South Conference,2,SUH,SHO,GASH,30151
+Siena Heights Saints,Siena Heights University,Saints,Mid-States Football Association,NAIA,SH,SHU,MISH,504800
+Simon Fraser Clan,Simon Fraser University,Clan,Great Northwest Athletic Conference,2,SIF,SFU,CNSF,30127
+Simpson Storm,Simpson College,Storm,Iowa Intercollegiate Athletic Conference,3,SIM,SC,IASI,641
+Sioux Falls Cougars,University of Sioux Falls,Cougars,Northern Sun Intercollegiate Conference,2,SFC,SF,SDSF,30128
+SJC Pumas,St. Joseph's College,Pumas,Great Lakes Valley Conference,2,SJC,SJ,INSJ,604
+Slippery Rock The Rock,Slippery Rock University,The Rock,Pennsylvania State Athletic Conference,2,SLI,SRU,PASR,643
+South Alabama Jaguars,University of South Alabama,Jaguars,Sun Belt Conference,1A,USA,SA,ALSO,646
+South Carolina Gamecocks,University of South Carolina,Gamecocks,Southeastern Conference,1A,SC,USC,SCUN,648
+South Carolina State Bulldogs,South Carolina State University,Bulldogs,Mid-Eastern Athletic Conference,1AA,SCS,SC,SCST,647
+South Dakota Coyotes,University of South Dakota,Coyotes,Missouri Valley Football Conference,1AA,SDC,USD,SDVE,650
+South Dakota School of Mines Hardrockers,South Dakota School of Mines and Technology,Hardrockers,Great Northwest Athletic Conference,2,SDM,SDT,SDMI,30139
+South Dakota State Jackrabbits,South Dakota State University,Jackrabbits,Missouri Valley Football Conference,1AA,SDJ,SD,SDST,649
+South Florida Bulls,University of South Florida,Bulls,American Athletic Conference,1A,USF,SFL,FLSO,651
+Southeast Missouri Redhawks,Southeast Missouri State University,Redhawks,Ohio Valley Conference,1AA,SEM,SMS,MOSE,654
+Southeastern Fire,Southeastern University,Fire,The Sun Conference,NAIA,SE,SEU,FLSE,506151
+Southeastern Louisiana Lions,Southeastern Louisiana University,Lions,Southland Conference,1AA,SEL,SLU,LASE,655
+Southeastern Oklahoma Savage Storm,Southeastern Oklahoma State University,Savage Storm,Great American Conference,2,SEO,SE,OKSE,1371
+Southern Arkansas Muleriders,Southern Arkansas University,Muleriders,Great American Conference,2,SAU,SA,ARMA,1376
+Southern California Trojans,University of Southern California,Trojans,Pacific Twelve Conference,1A,USC,SC,CASC,657
+Southern Connecticut Owls,Southern Connecticut State University,Owls,Northeast-10 Conference,2,SCT,SCS,CTSO,658
+Southern Illinois Salukis,Southern Illinois University,Salukis,Missouri Valley Football Conference,1AA,SIU,SOI,ILSO,659
+Southern Jaguars,Southern University,Jaguars,Southwestern Athletic Conference,1AA,SOU,SU,LASO,665
+Southern Methodist Mustangs,Southern Methodist University,Mustangs,American Athletic Conference,1A,SMU,SOU,TXMU,663
+Southern Mississippi Golden Eagles,University of Southern Mississippi,Golden Eagles,Conference USA,1A,USM,SM,MSSO,664
+Southern Nazarene Crimson Storm,Southern Nazarene University,Crimson Storm,Great American Conference,2,SN,SNU,OKSN,30152
+Southern Oregon Raiders,Southern Oregon University,Raiders,Frontier Conference,NAIA,SOU,SO,ORSO,506027
+Southern Utah Thunderbirds,Southern Utah University,Thunderbirds,Big Sky Conference,1AA,SUU,SU,UTSO,667
+Southern Virginia Knights,Southern Virginia University,Knights,New Jersey Athletic Conference,3,SVK,SVU,VASI,30164
+Southwest Baptist Bearcats,Southwest Baptist University,Bearcats,Great Lakes Valley Conference,2,SWB,SBU,MOSB,2755
+Southwest Minnesota Mustangs,Southwest Minnesota State University,Mustangs,Northern Sun Intercollegiate Conference,2,SWM,SMN,MNSW,8736
+Southwestern Assemblies of God Lions,Southwestern Assemblies of God College,Lions,Central States Football League,NAIA,SAG,SWG,TXSA,506149
+Southwestern Moundbuilders,Southwestern College,Moundbuilders,Kansas Collegiate Athletic Conference,NAIA,SW,SWC,KSSW,506063
+Southwestern Oklahoma State Bulldogs,Southwestern Oklahoma State University,Bulldogs,Great American Conference,2,SWO,SOS,OKSW,8744
+Southwestern Pirates,Southwestern University,Pirates,Southern Collegiate Athletic Conference,3,SW,SWU,TXSU,8746
+Springfield Pride,Springfield College,Pride,Liberty League,3,SPR,SC,MASP,673
+St. Ambrose Fighting Bees,St. Ambrose University,Fighting Bees,Mid-States Football Association,NAIA,SA,SAU,IASA,506002
+St. Andrews University,St. Andrews University,Knights,Independent,NAIA,SNT,SAU,NCAN,506422
+St. Cloud Huskies,St. Cloud State University,Huskies,Northern Sun Intercollegiate Conference,2,SCH,SC,MNSC,598
+St. Francis Cougars,St. Francis,Cougars,Mid-States Football Association,NAIA,SF,SFI,INSF,504500
+St. John Fisher Cardinals,St. John Fisher College,Cardinals,Empire 8 Conference,3,SJF,SJ,NYJF,601
+St. John's Johnnies,St. John's University,Johnnies,Minnesota Intercollegiate Athletic Conference,3,SJ,SJU,MNSJ,602
+St. Lawrence Saints,St. Lawrence University,Saints,Liberty League,3,SL,SLU,NYSL,607
+St. Norbert Green Knights,St. Norbert College,Green Knights,Midwest Conference,3,SGK,SNC,WISN,614
+St. Olaf Lions,St. Olaf College,Lions,Minnesota Intercollegiate Athletic Conference,3,SO,SOC,MNSO,615
+St. Scholastica Saints,The College of St. Scholastica,Saints,Upper Midwest Athletic Conference,3,CSS,SS,MNSS,618
+St. Thomas Tommies,University of St. Thomas,Tommies,Minnesota Intercollegiate Athletic Conference,3,ST,UST,MNST,620
+Stanford Cardinal,Stanford University,Cardinal,Pacific Twelve Conference,1A,STA,SU,CAST,674
+Stephen F. Austin Lumberjacks,Stephen F. Austin State University,Lumberjacks,Southland Conference,1AA,SFA,SAS,TXSF,676
+Sterling Warriors,Sterling College,Warriors,Kansas Collegiate Athletic Conference,NAIA,STE,SC,KSSG,506073
+Stetson Hatters,Stetson University,Hatters,Pioneer Football League,1AA,STE,SU,FLSS,678
+Stevenson Mustangs,Stevenson University,Mustangs,Middle Atlantic Conference,3,SUM,STE,MDSN,21852
+Stillman Tigers,Stillman College,Tigers,Southern Intercollegiate Athletic Conference,2,STI,SC,ALSL,680
+Stonehill Skyhawks,Stonehill College,Skyhawks,Northeast-10 Conference,2,STS,STO,MAST,682
+Stony Brook Seawolves,Stony Brook University,Seawolves,Colonial Athletic Association,1AA,STO,SBU,NYST,683
+Sul Ross Lobos,Sul Ross State University,Lobos,American Southwest Conference,3,SRS,SUL,TXSR,1390
+SUNY-Brockport Golden Eagles,SUNY-Brockport,Golden Eagles,Empire 8 Conference,3,BRO,SNY,NYBP,78
+Susquehanna Crusaders,Susquehanna University,Crusaders,Centennial Conference,3,SUC,SUS,PASU,685
+Syracuse Orangemen,Syracuse University,Orangemen,Atlantic Coast Conference,1A,SYR,SU,NYSY,688
+Tabor Bluejays,Tabor College,Bluejays,Kansas Collegiate Athletic Conference,NAIA,TAB,TC,KSTA,506050
+Tarleton State Texans,Tarleton State University,Texans,Lone Star Conference,2,TAR,TSU,TXTA,1395
+Taylor Trojans,Taylor University,Trojans,Mid-States Football Association,NAIA,TAY,TU,INTA,506071
+Temple Owls,Temple University,Owls,American Athletic Conference,1A,TEM,TU,PATE,690
+Tennessee State Tigers,Tennessee State University,Tigers,Ohio Valley Conference,1AA,TNS,TEN,TNAI,691
+Tennessee Tech Golden Eagles,Tennessee Tech University,Golden Eagles,Ohio Valley Conference,1AA,TNT,TEN,TNTC,692
+Tennessee Volunteers,University of Tennessee,Volunteers,Southeastern Conference,1A,TN,TEN,TNUN,694
+Tennessee-Chattanooga Mocs,University of Tennessee-Chattanooga,Mocs,Southern Conference,1AA,TCH,TEN,TNCH,693
+Tennessee-Martin Skyhawks,University of Tennessee-Martin,Skyhawks,Ohio Valley Conference,1AA,UTM,TEN,TNMR,695
+Texas A&M Aggies,Texas A&M University,Aggies,Southeastern Conference,1A,TAM,TEX,TXAM,697
+Texas A&M-Commerce Lions,Texas A&M University-Commerce,Lions,Lone Star Conference,2,TCL,TAC,TXEA,199
+Texas A&M-Kingsville Javelinas,Texas A&M University-Kingsville,Javelinas,Lone Star Conference,2,TKJ,TAK,TXAI,696
+Texas Christian Horned Frogs,Texas Christian University,Horned Frogs,Big Twelve Conference,1A,TCU,TEX,TXCU,698
+Texas Longhorns,University of Texas,Longhorns,Big Twelve Conference,1A,TX,TEX,TXUN,703
+Texas Lutheran Bulldogs,Texas Lutheran University,Bulldogs,Southern Collegiate Athletic Conference,3,TLU,TEX,TXLU,1400
+Texas Southern Tigers,Texas Southern University,Tigers,Southwestern Athletic Conference,1AA,TST,TEX,TXSO,699
+Texas State Bobcats,Texas State University,Bobcats,Sun Belt Conference,1A,TSU,TEX,TXSW,670
+Texas Steers,Texas College,Steers,Central States Football League,NAIA,TEX,TC,TXCL,505260
+Texas Tech Red Raiders,Texas Tech University,Red Raiders,Big Twelve Conference,1A,TTU,TEX,TXTC,700
+Texas-El Paso Miners,University of Texas-El Paso,Miners,Conference USA,1A,TEP,TEL,TXEP,704
+The Apprentice School Builders,The Apprentice School,Builders,Independent,3,ASB,TAS,VANN,506125
+Thiel Tomcats,Thiel College,Tomcats,Presidents Athletic Conference,3,THL,TC,PATH,707
+Thomas More Saints,Thomas More College,Saints,Presidents Athletic Conference,3,TMC,THO,KYTM,1402
+Tiffin Dragons,Tiffin University,Dragons,Great Lakes Intercollegiate Athletic Conference,2,TIF,TU,OHTI,1403
+Toledo Rockets,University of Toledo,Rockets,Mid-American Conference,1A,TOL,UT,OHTO,709
+Towson Tigers,Towson University,Tigers,Colonial Athletic Association,1AA,TOW,TU,MDTO,711
+Trine Thunder,Trine,Thunder,Michigan Intercollegiate Athletic Association,3,TRI,T,INTR,30037
+Trinity Bantams,Trinity College,Bantams,New England Small College Athletic Conference,3,TCB,TC,CTTR,713
+Trinity International Trojans,Trinity International University,Trojans,Mid-States Football Association,NAIA,TRI,TIU,ILTR,506107
+Trinity Tigers,Trinity University,Tigers,Southern Collegiate Athletic Conference,3,TUT,TU,TXTR,715
+Troy Trojans,Troy University,Trojans,Sun Belt Conference,1A,TRY,TRO,ALTR,716
+Truman State Bulldogs,Truman State University,Bulldogs,Great Lakes Valley Conference,2,TRU,TSU,MONE,499
+Tufts Jumbos,Tufts University,Jumbos,New England Small College Athletic Conference,3,TUF,TU,MATU,717
+Tulane Green Wave,Tulane University,Green Wave,American Athletic Conference,1A,TUL,TU,LATU,718
+Tulsa Golden Hurricane,University of Tulsa,Golden Hurricane,American Athletic Conference,1A,TGH,UT,OKTU,719
+Tusculum Pioneers,Tusculum College,Pioneers,South Atlantic Conference,2,TUS,TC,TNTU,12830
+Tuskegee Golden Tigers,Tuskegee University,Golden Tigers,Southern Intercollegiate Athletic Conference,2,TGT,TU,ALTU,720
+Tyler Apaches,Tyler Junior College,Apaches,Southwest Junior College Football Conference,NJCAA,TJC,TYL,TXTY,30028
+UMass Dartmouth Corsairs,University of Massachusetts-Dartmouth,Corsairs,Massachusetts State College Athletic Conference,3,MDC,MD,MASE,656
+Union Bulldogs,Union College,Bulldogs,Mid-South Conference,NAIA,UC,UNI,KYUC,506105
+Union Dutchmen,Union College (N.Y.),Dutchmen,Liberty League,3,UD,UC,NYUN,727
+University of St. Francis (Ill.),University of St. Francis (Ill.),Fighting Saints,Mid-States Football Association,NAIA,SFI,A,ILSF,506180
+University of West Florida,University of West Florida,University of West Florida,Gulf South Conference,2,UWF,WFA,FLWS,11740
+Upper Iowa Peacocks,Upper Iowa University,Peacocks,Northern Sun Intercollegiate Conference,2,UI,UIU,IAUP,728
+Urbana Blue Knights,Urbana University,Blue Knights,Mountain East Conference,2,URB,UU,OHUR,30104
+Ursinus Bears,Ursinus College,Bears,Centennial Conference,3,URS,UC,PAUR,730
+Utah State Aggies,Utah State University,Aggies,Mountain West Conference,1A,USU,UTS,UTST,731
+Utah Utes,University of Utah,Utes,Pacific Twelve Conference,1A,UT,UU,UTUN,732
+Utica Pioneers,Utica College,Pioneers,Empire 8 Conference,3,UTI,UC,NYUT,733
+UTPB Falcons,University of Texas of the Permian Basin,Falcons,Lone Star Conference,2,TPB,TXP,TXPB,30088
+UTSA Roadrunners,University of Texas - San Antonio,Roadrunners,Conference USA,1A,TSA,A,TXSN,706
+Valdosta State Blazers,Valdosta State University,Blazers,Gulf South Conference,2,VSB,VSU,GAVA,734
+Valley Vikings,Valley City State University,Vikings,North Star Athletic Association,NAIA,VAL,VCS,NDVA,506055
+Valparaiso Crusaders,Valparaiso University,Crusaders,Pioneer Football League,1AA,VAL,VU,INVA,735
+Vanderbilt Commodores,Vanderbilt University,Commodores,Southeastern Conference,1A,VAN,VU,TNVA,736
+Villanova Wildcats,Villanova University,Wildcats,Colonial Athletic Association,1AA,VIL,VU,PAVI,739
+Virginia at Wise Cavaliers,University of Virginia's College at Wise,Cavaliers,Mountain East Conference,2,VAW,VA,VACV,30181
+Virginia Cavaliers,University of Virginia,Cavaliers,Atlantic Coast Conference,1A,VA,VIR,VAUN,746
+Virginia Military Institute Keydets,Virginia Military Institute,Keydets,Southern Conference,1AA,VMI,VIR,VAMI,741
+Virginia Polytechnic Hokies,Virginia Polytechnic Institute and State University,Hokies,Atlantic Coast Conference,1A,VPI,VIR,VAPI,742
+Virginia State Trojans,Virginia State University,Trojans,Central Intercollegiate Athletic Association,2,VIR,VSU,VAPE,743
+Virginia Union Panthers,Virginia Union University,Panthers,Central Intercollegiate Athletic Association,2,VUU,VIR,VAVU,744
+Virginia University of Lynchburg Dragons,Virginia University of Lynchburg,Dragons,Independent,OTHER,VUL,VLY,VALY,506391
+Wabash Little Giants,Wabash College,Little Giants,North Coast Athletic Conference,3,WAB,WC,INWA,747
+Wagner Seahawks,Wagner College,Seahawks,Northeast Conference,1AA,WAG,WC,NYWA,748
+Wake Forest Demon Deacons,Wake Forest University,Demon Deacons,Atlantic Coast Conference,1A,WF,WFU,NCWF,749
+Waldorf Warriors,Waldorf College,Warriors,Mid-States Football Association,NAIA,WAL,WC,IAWL,506242
+Walsh Cavaliers,Walsh University,Cavaliers,Great Lakes Intercollegiate Athletic Conference,2,WAL,WU,OHWA,30141
+Warner Royals,Warner University,Royals,The Sun Conference,NAIA,WAR,WU,FLWR,505562
+Wartburg Knights,Wartburg College,Knights,Iowa Intercollegiate Athletic Conference,3,WAR,WC,IAWA,750
+Washburn Ichabods,Washburn University,Ichabods,Mid-America Intercollegiate Athletic Association,2,WAS,WU,KSWA,2814
+Washington & Jefferson Presidents,Washington & Jefferson College,Presidents,Presidents Athletic Conference,3,WJP,WJU,PAWJ,751
+Washington & Lee Generals,Washington & Lee University,Generals,Old Dominion Athletic Conference,3,WLU,WAS,VAWL,752
+Washington Bears,Washington University (Mo.),Bears,Independent,3,WUB,WUM,MOWA,755
+Washington Huskies,University of Washington,Huskies,Pacific Twelve Conference,1A,WA,UW,WAUN,756
+Washington State Cougars,Washington State University,Cougars,Pacific Twelve Conference,1A,WSC,WAS,WAST,754
+Wayland Baptist Pioneers,Wayland Baptist University,Pioneers,Central States Football League,NAIA,WAY,WB,TXWB,505610
+Wayne State Warriors,Wayne State University,Warriors,Great Lakes Intercollegiate Athletic Conference,2,WAY,WSU,MIWA,757
+Wayne State Wildcats,Wayne State College (Neb.),Wildcats,Northern Sun Intercollegiate Conference,2,WSW,WSC,NEWA,1433
+Waynesburg Yellow Jackets,Waynesburg University,Yellow Jackets,Presidents Athletic Conference,3,WYJ,WU,PAWB,1434
+Webber Warriors,Webber International University,Warriors,The Sun Conference,NAIA,WIU,WEB,FLWE,505632
+Weber State Wildcats,Weber State University,Wildcats,Big Sky Conference,1AA,WEB,WSU,UTWB,758
+Wesley Wolverines,Wesley College,Wolverines,New Jersey Athletic Conference,3,WCW,WC,DEWC,763
+Wesleyan Cardinals,Wesleyan University,Cardinals,New England Small College Athletic Conference,3,WUC,WU,CTWS,764
+West Alabama Tigers,University of West Alabama,Tigers,Gulf South Conference,2,UWA,WA,ALLI,358
+West Chester Golden Rams,West Chester University,Golden Rams,Pennsylvania State Athletic Conference,2,WCU,CHE,PAWC,765
+West Georgia Wolves,University of West Georgia,Wolves,Gulf South Conference,2,WG,WGA,GAWG,766
+West Liberty Hilltoppers,West Liberty University,Hilltoppers,Mountain East Conference,2,WL,WlU,WVWL,1438
+West Texas A&M Buffalos,West Texas A&M University,Buffalos,Lone Star Conference,2,WTA,TAM,TXWE,767
+West Virginia Mountaineers,West Virginia University,Mountaineers,Big Twelve Conference,1A,WV,WVU,WVUN,768
+West Virginia State Yellow Jackets,West Virginia State College,Yellow Jackets,Mountain East Conference,2,WVS,WV,WVST,1439
+West Virginia Tech Golden Bears,West Virginia Tech,Golden Bears,NO FOOTBALL,NAIA,WVT,WEV,WVIT,14901
+West Virginia Wesleyan Bobcats,West Virginia Wesleyan College,Bobcats,Mountain East Conference,2,WVW,WV,WVWE,9630
+Western Carolina Catamounts,Western Carolina University,Catamounts,Southern Conference,1AA,WC,WCU,NCWE,769
+Western Connecticut Colonials,Western Connecticut State University,Colonials,Massachusetts State College Athletic Conference,3,WCS,WC,CTWE,770
+Western Illinois Leathernecks,Western Illinois University,Leathernecks,Missouri Valley Football Conference,1AA,WIU,WES,ILWE,771
+Western Kentucky Hilltoppers,Western Kentucky University,Hilltoppers,Conference USA,1A,WKU,WES,KYWE,772
+Western Michigan Broncos,Western Michigan University,Broncos,Mid-American Conference,1A,WMU,WM,MIWE,774
+Western New England Golden Bears,Western New England College,Golden Bears,New England Football Conference,3,WNE,WNC,MAWE,775
+Western New Mexico Mustangs,Western New Mexico University,Mustangs,Rocky Mountain Athletic Conference,2,WNM,NM,NMWE,1445
+Western Oregon Wolves,Western Oregon University,Wolves,Great Northwest Athletic Conference,2,WOU,WES,ORCL,1446
+Western State Mountaineers,Western State College,Mountaineers,Rocky Mountain Athletic Conference,2,WES,WSC,COWE,2759
+Westfield Owls,Westfield State College,Owls,Massachusetts State College Athletic Conference,3,WSO,WSC,MAWF,777
+Westminster Blue Jays,Westminster College,Blue Jays,Upper Midwest Athletic Conference,3,WBJ,WC,MOWM,1450
+Westminster Titans,Westminster College,Titans,Presidents Athletic Conference,3,WCT,WES,PAWM,1451
+Wheaton Thunder,Wheaton College (Ill.),Thunder,College Conference of Illinois and Wisconsin,3,WHE,WC,ILWH,778
+Whittier Poets,Whittier College,Poets,Southern California Intercollegiate Athletic Conf.,3,WHI,WC,CAWH,781
+Whitworth Pirates,Whitworth College,Pirates,Northwest Conference,3,WCP,WC,WAWW,1454
+Widener Pride,Widener University,Pride,Middle Atlantic Conference,3,WID,WU,PAWD,783
+Wilkes Colonels,Wilkes University,Colonels,Middle Atlantic Conference,3,WLK,WU,PAWL,784
+Willamette Bearcats,Willamette University,Bearcats,Northwest Conference,3,WIL,WU,ORWI,785
+William & Mary Tribe,College of William & Mary,Tribe,Colonial Athletic Association,1AA,CWM,WM,VAWM,786
+William Jewell Cardinals,William Jewell College,Cardinals,Great Lakes Valley Conference,2,WJ,WJC,MOWJ,30120
+William Paterson Pioneers,William Paterson University,Pioneers,New Jersey Athletic Conference,3,WPP,WPU,NJWP,787
+William Penn Statemen,William Penn University,Statemen,Mid-States Football Association,NAIA,WPU,WIL,IAWP,506401
+Williams Ephs,Williams College,Ephs,New England Small College Athletic Conference,3,WCE,WC,MAWI,789
+Wilmington Quakers,Wilmington College,Quakers,Ohio Athletic Conference,3,WCQ,WC,OHWL,1461
+Wingate Bulldogs,Wingate University,Bulldogs,South Atlantic Conference,2,WIN,WU,NCWI,1462
+Winona State Warriors,Winona State University,Warriors,Northern Sun Intercollegiate Conference,2,WNS,WSU,MNWI,790
+Winston-Salem Rams,Winston-Salem State University,Rams,Central Intercollegiate Athletic Association,2,WSS,WIN,NCWS,791
+Wisconsin Badgers,University of Wisconsin,Badgers,Big Ten Conference,1A,WI,WIS,WIUN,796
+Wisconsin Lutheran Warriors,Wisconsin Lutheran College,Warriors,Northern Athletics Conference,3,WLW,WIS,WILU,8911
+Wisconsin-Eau Claire Blugolds,University of Wisconsin-Eau Claire,Blugolds,Wisconsin Intercollegiate Athletic Conference,3,WEC,WIS,WIEC,793
+Wisconsin-LaCrosse Eagles,University of Wisconsin-LaCrosse,Eagles,Wisconsin Intercollegiate Athletic Conference,3,WLC,WIS,WILC,795
+Wisconsin-Oshkosh Titans,University of Wisconsin-Oshkosh,Titans,Wisconsin Intercollegiate Athletic Conference,3,WOS,WIS,WIOS,798
+Wisconsin-Platteville Pioneers,University of Wisconsin-Platteville,Pioneers,Wisconsin Intercollegiate Athletic Conference,3,WP,WIS,WIPL,800
+Wisconsin-River Falls Falcons,University of Wisconsin-River Falls,Falcons,Wisconsin Intercollegiate Athletic Conference,3,WRF,RF,WIRF,801
+Wisconsin-Stevens Point Pointers,University of Wisconsin-Stevens Point,Pointers,Wisconsin Intercollegiate Athletic Conference,3,WSP,WIS,WISP,802
+Wisconsin-Stout Blue Devils,University of Wisconsin-Stout,Blue Devils,Wisconsin Intercollegiate Athletic Conference,3,WST,WIS,WIME,803
+Wisconsin-Whitewater Warhawks,University of Wisconsin-Whitewater,Warhawks,Wisconsin Intercollegiate Athletic Conference,3,WWH,WIS,WIWH,805
+Wittenberg Tigers,Wittenberg University,Tigers,North Coast Athletic Conference,3,WIT,WU,OHWT,806
+Wofford Terriers,Wofford College,Terriers,Southern Conference,1AA,WOF,WC,SCWO,2915
+Wooster Fighting Scots,College of Wooster,Fighting Scots,North Coast Athletic Conference,3,WOO,CW,OHWO,807
+Worcester State Lancers,Worcester State College,Lancers,Massachusetts State College Athletic Conference,3,WSL,WOR,MAWS,809
+WPI Engineers,Worcester Polytechnic Institute,Engineers,Liberty League,3,WPI,WOR,MAWP,808
+Wyoming Cowboys,University of Wyoming,Cowboys,Mountain West Conference,1A,WY,WYO,WYUN,811
+Yale Bulldogs,Yale University,Bulldogs,Ivy League,1AA,YAL,YU,CTYA,813
+Youngstown State Penguins,Youngstown State University,Penguins,Missouri Valley Football Conference,1AA,YOU,YSU,OHYO,817


### PR DESCRIPTION
Added a spreadsheet with commonly accepted team abreviations for CFB teams. Sourced from the following website:
https://www.nflgsis.com/gsis/documentation/Partners/Schools.htm